### PR TITLE
enable multi-arch build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,12 @@ ARG IMAGE_BUILD_GO=golang:1.17-buster
 ARG IMAGE_BASE_DEBUG=gcr.io/distroless/static-debian10:debug
 ARG IMAGE_BASE=gcr.io/distroless/static-debian10
 
-FROM ${IMAGE_BUILD_GO} AS gobase
+FROM --platform=$BUILDPLATFORM ${IMAGE_BUILD_GO} AS gobase
 
 # Compile the UI assets.
-FROM ${IMAGE_BUILD_NODEJS} as assets
+FROM --platform=$BUILDPLATFORM ${IMAGE_BUILD_NODEJS} as assets
 # To build the UI we need a recent node version and the go toolchain.
+ARG TARGETOS TARGETARCH
 RUN install_node v17.9.0
 COPY --from=gobase /usr/local/go /usr/local/
 ENV PATH="/usr/local/go/bin:${PATH}"
@@ -21,14 +22,17 @@ RUN make npm_licenses
 
 # Build the actual Go binary.
 FROM gobase as buildbase
+ARG TARGETOS TARGETARCH
 WORKDIR /app
 COPY --from=assets /app ./
-RUN CGO_ENABLED=0 go build \
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    CGO_ENABLED=0 go build \
     -tags builtinassets -mod=vendor \
     -ldflags="-X github.com/prometheus/common/version.Version=$(cat VERSION) \
     -X github.com/prometheus/common/version.BuildDate=$(date --iso-8601=seconds)" \
     ./cmd/prometheus
-RUN CGO_ENABLED=0 go build \
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    CGO_ENABLED=0 go build \
     -mod=vendor \
     -ldflags="-X github.com/prometheus/common/version.Version=$(cat VERSION) \
     -X github.com/prometheus/common/version.BuildDate=$(date --iso-8601=seconds)" \
@@ -37,7 +41,7 @@ RUN CGO_ENABLED=0 go build \
 # Configure distroless base image like the upstream Prometheus image.
 # Since the directory and symlink setup needs shell access, we need yet another
 # intermediate stage.
-FROM ${IMAGE_BASE_DEBUG} as appbase
+FROM --platform=$BUILDPLATFORM ${IMAGE_BASE_DEBUG} as appbase
 
 COPY documentation/examples/prometheus.yml  /etc/prometheus/prometheus.yml
 COPY console_libraries/                     /usr/share/prometheus/console_libraries/
@@ -45,7 +49,7 @@ COPY consoles/                              /usr/share/prometheus/consoles/
 RUN ["/busybox/sh", "-c", "ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles/ /etc/prometheus/"]
 RUN ["/busybox/sh", "-c", "mkdir -p /prometheus"]
 
-FROM ${IMAGE_BASE}
+FROM --platform=$BUILDPLATFORM ${IMAGE_BASE}
 
 COPY --from=buildbase /app/prometheus /bin/prometheus
 COPY --from=buildbase /app/promtool /bin/promtool

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ GOLANGCI_LINT_OPTS ?= --timeout 4m
 include Makefile.common
 
 DOCKER_IMAGE_NAME       ?= prometheus
+TAG_NAME?=$(shell date "+gmp-%Y%d%m_%H%M")
+PROJECT_ID?=$(shell gcloud config get-value core/project)
 
 .PHONY: update-npm-deps
 update-npm-deps:
@@ -114,3 +116,8 @@ bench_tsdb: $(PROMU)
 	@$(GO) tool pprof --alloc_space -svg $(PROMTOOL) $(TSDB_BENCHMARK_OUTPUT_DIR)/mem.prof > $(TSDB_BENCHMARK_OUTPUT_DIR)/memprof.alloc.svg
 	@$(GO) tool pprof -svg $(PROMTOOL) $(TSDB_BENCHMARK_OUTPUT_DIR)/block.prof > $(TSDB_BENCHMARK_OUTPUT_DIR)/blockprof.svg
 	@$(GO) tool pprof -svg $(PROMTOOL) $(TSDB_BENCHMARK_OUTPUT_DIR)/mutex.prof > $(TSDB_BENCHMARK_OUTPUT_DIR)/mutexprof.svg
+
+.PHONY: cloudbuild
+cloudbuild:  ## Build images on Google Cloud Build.
+	@echo ">> building Multi-arch(AMD64 and ARM64) GMP prometheus images on Cloud Build with tag: $(TAG_NAME)"
+	gcloud builds submit --config cloudbuild.yaml --timeout=2h --substitutions=TAG_NAME="$(TAG_NAME)"


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->