### PR TITLE
Bump to prometheus-engine 0.6.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v63.0.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.25
 	github.com/Azure/go-autorest/autorest/adal v0.9.18
-	github.com/GoogleCloudPlatform/prometheus-engine v0.6.1-rc.0
+	github.com/GoogleCloudPlatform/prometheus-engine v0.6.2-rc.0
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
 	github.com/aws/aws-sdk-go v1.43.31
 	github.com/cespare/xxhash/v2 v2.1.2

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
-github.com/GoogleCloudPlatform/prometheus-engine v0.6.1-rc.0 h1:ASw+xYV6mvp5Bo7pDWNCpUR8dKxc41+qMYCCcfTZkog=
-github.com/GoogleCloudPlatform/prometheus-engine v0.6.1-rc.0/go.mod h1:Nlw5qiRRxzqPIZ+LM50QraTaidizouftC6NTqo5azjI=
+github.com/GoogleCloudPlatform/prometheus-engine v0.6.2-rc.0 h1:zLFhuvAbXsRfJFKIHkywuKIlDL9aB+j7nWVDwhbdeVA=
+github.com/GoogleCloudPlatform/prometheus-engine v0.6.2-rc.0/go.mod h1:Nlw5qiRRxzqPIZ+LM50QraTaidizouftC6NTqo5azjI=
 github.com/HdrHistogram/hdrhistogram-go v0.9.0/go.mod h1:nxrse8/Tzg2tg3DZcZjm6qEclQKK70g0KxO61gFFZD4=
 github.com/HdrHistogram/hdrhistogram-go v1.0.1/go.mod h1:BWJ+nMSHY3L41Zj7CA3uXnloDp7xxV0YvstAE7nKTaM=
 github.com/HdrHistogram/hdrhistogram-go v1.1.0/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=

--- a/vendor/github.com/GoogleCloudPlatform/prometheus-engine/pkg/export/setup/setup.go
+++ b/vendor/github.com/GoogleCloudPlatform/prometheus-engine/pkg/export/setup/setup.go
@@ -48,6 +48,8 @@ const (
 	UAModeGKE         = "gke"
 	UAModeKubectl     = "kubectl"
 	UAModeUnspecified = "unspecified"
+	UAModeAVMW        = "on-prem"
+	UAModeABM         = "baremetal"
 )
 
 // Environment variable that contains additional command line arguments.
@@ -131,8 +133,8 @@ func FromFlags(a *kingpin.Application, userAgentProduct string) func(log.Logger,
 	a.Flag("export.label.project-id", fmt.Sprintf("Default project ID set for all exported data. Prefer setting the external label %q in the Prometheus configuration if not using the auto-discovered default.", export.KeyProjectID)).
 		Default(opts.ProjectID).StringVar(&opts.ProjectID)
 
-	a.Flag("export.user-agent-mode", fmt.Sprintf("Mode for user agent used for requests against the GCM API. Valid values are %q, %q, or %q.", UAModeGKE, UAModeKubectl, UAModeUnspecified)).
-		Default("unspecified").EnumVar(&opts.UserAgentMode, UAModeUnspecified, UAModeGKE, UAModeKubectl)
+	a.Flag("export.user-agent-mode", fmt.Sprintf("Mode for user agent used for requests against the GCM API. Valid values are %q, %q, %q, %q or %q.", UAModeGKE, UAModeKubectl, UAModeAVMW, UAModeABM, UAModeUnspecified)).
+		Default("unspecified").EnumVar(&opts.UserAgentMode, UAModeUnspecified, UAModeGKE, UAModeKubectl, UAModeAVMW, UAModeABM)
 
 	// The location and cluster flag should probably not be used. On the other hand, they make it easy
 	// to populate these important values in the monitored resource without interfering with existing

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -27,7 +27,7 @@ github.com/Azure/go-autorest/autorest/validation
 github.com/Azure/go-autorest/logger
 # github.com/Azure/go-autorest/tracing v0.6.0
 github.com/Azure/go-autorest/tracing
-# github.com/GoogleCloudPlatform/prometheus-engine v0.6.1-rc.0
+# github.com/GoogleCloudPlatform/prometheus-engine v0.6.2-rc.0
 ## explicit
 github.com/GoogleCloudPlatform/prometheus-engine/pkg/export
 github.com/GoogleCloudPlatform/prometheus-engine/pkg/export/setup


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->

Use latest prometheus-engine export library to support other user agent enums.