### PR TITLE
Disable unused lock threads cron

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,9 +1,6 @@
 name: 'Lock Threads'
 
-on:
-  schedule:
-    - cron: '13 23 * * *'
-  workflow_dispatch:
+on: workflow_dispatch
 
 permissions:
   issues: write


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/prometheus/actions?query=branch%3Arelease-2.35.0-gmp

It's very noisy and does nothing for us. It just runs this bot:
![](https://raw.githubusercontent.com/dessant/lock-threads/master/assets/screenshot.png)