### PR TITLE
Commenting on the PR with prombench's status

### DIFF
--- a/.github/workflows/prombench-gmp-collector.yml
+++ b/.github/workflows/prombench-gmp-collector.yml
@@ -13,7 +13,7 @@ env:
   CLUSTER_NAME: prombench
   COLLECTOR_IMAGE_REPOSITORY: gke.gcr.io/prometheus-engine/prometheus
   CREATE_CLUSTER: "true"
-  DASHBOARD_ID: 33755240-08f9-4db9-a86f-839481fd5002
+  DASHBOARD_ID: 8dc0ed11-c0bd-4fb3-9cdf-1ef8ae04bdad
   DISABLE_LOADGEN_QUERIER: "true"
   DOMAIN_NAME: ""
   GITHUB_ORG: ${{ github.repository_owner }} # GoogleCloudPlatform
@@ -113,6 +113,20 @@ jobs:
 
           fi
 
+      - name: post_comment_to_pr
+        if: env.CANCEL_BENCHMARK == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          MONITORING_DASHBOARD_URL="https://console.cloud.google.com/monitoring/dashboards/builder/${DASHBOARD_ID};duration=PT15M"
+          
+          COMMENT_MSG="This benchmark run compares this PR (https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/pull/${PR_NUMBER}) with version \`${COLLECTOR_RELEASE_VERSION}\` of the [GMP Collector](https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed).\n\nAfter a successful deployment, the benchmarking results can be viewed on the [Cloud Monitoring Dashboard](${MONITORING_DASHBOARD_URL}).\n\nTo cancel or stop the benchmark run, comment \`/prombench cancel\` on this PR."
+
+          curl --silent -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/issues/${PR_NUMBER}/comments \
+            --data '{ "body": "'"${COMMENT_MSG}"'" }'
+
       
       - name: check_cluster_existance
         run: |
@@ -154,23 +168,6 @@ jobs:
         uses: docker://saketjajoo/prombench:latest
         with:
             args: make resource_apply;
-
-      
-      - name: post_benchmark_dashboard_url_to_pr
-        if: env.CANCEL_BENCHMARK == 'false'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          MONITORING_DASHBOARD_URL="https://console.cloud.google.com/monitoring/dashboards/builder/${DASHBOARD_ID};duration=PT15M?f.rlabel.cluster_name=${CLUSTER_NAME}&f.rlabel.namespace=prombench-${PR_NUMBER}&f.umlabel.goog-k8s-cluster-name=${CLUSTER_NAME}"
-          
-          
-          COMMENT_MSG="The benchmark results can be viewed at: ${MONITORING_DASHBOARD_URL}.\n\nTo cancel the benchmark, comment \`/prombench cancel\` on this PR."
-
-          curl --silent -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/issues/${PR_NUMBER}/comments \
-            --data '{ "body": "'"${COMMENT_MSG}"'" }'
-
       
       - name: node_delete
         if: env.CANCEL_BENCHMARK == 'true'


### PR DESCRIPTION
Right after a "verified" user triggers a benchmark run, a message would be posted on the PR as a comment about the status of the prombench trigger along with the dashboard's link where the results can be viewed.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
