### PR TITLE
Use structured logging

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -214,6 +214,8 @@ func main() {
 		oldFlagRetentionDuration model.Duration
 		newFlagRetentionDuration model.Duration
 	)
+	af := promlog.AllowedFormat{}
+	af.Set("json")
 
 	cfg := flagConfig{
 		notifier: notifier.Options{
@@ -223,7 +225,7 @@ func main() {
 			Registerer: prometheus.DefaultRegisterer,
 			Gatherer:   prometheus.DefaultGatherer,
 		},
-		promlogConfig: promlog.Config{},
+		promlogConfig: promlog.Config{Format: &af},
 	}
 
 	a := kingpin.New(filepath.Base(os.Args[0]), "The Prometheus monitoring server").UsageWriter(os.Stdout)

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -214,8 +214,6 @@ func main() {
 		oldFlagRetentionDuration model.Duration
 		newFlagRetentionDuration model.Duration
 	)
-	af := promlog.AllowedFormat{}
-	af.Set("json")
 
 	cfg := flagConfig{
 		notifier: notifier.Options{
@@ -225,7 +223,6 @@ func main() {
 			Registerer: prometheus.DefaultRegisterer,
 			Gatherer:   prometheus.DefaultGatherer,
 		},
-		promlogConfig: promlog.Config{Format: &af},
 	}
 
 	a := kingpin.New(filepath.Base(os.Args[0]), "The Prometheus monitoring server").UsageWriter(os.Stdout)
@@ -410,7 +407,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	logger := promlog.New(&cfg.promlogConfig)
+	logger := log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
 
 	if err := cfg.setFeatureListOptions(logger); err != nil {
 		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "Error parsing feature list"))

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -223,6 +223,7 @@ func main() {
 			Registerer: prometheus.DefaultRegisterer,
 			Gatherer:   prometheus.DefaultGatherer,
 		},
+		promlogConfig: promlog.Config{},
 	}
 
 	a := kingpin.New(filepath.Base(os.Args[0]), "The Prometheus monitoring server").UsageWriter(os.Stdout)
@@ -407,7 +408,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	logger := log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
+	logger := log.NewJSONLogger(log.NewSyncWriter(os.Stderr))
 
 	if err := cfg.setFeatureListOptions(logger); err != nil {
 		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "Error parsing feature list"))

--- a/vendor/github.com/prometheus/common/promlog/log.go
+++ b/vendor/github.com/prometheus/common/promlog/log.go
@@ -113,7 +113,7 @@ type Config struct {
 func New(config *Config) log.Logger {
 	var l log.Logger
 	if config.Format != nil && config.Format.s == "json" {
-		l = log.NewJSONLogger(log.NewSyncWriter(os.Stderr))
+		l = log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
 	} else {
 		l = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 	}

--- a/vendor/github.com/prometheus/common/promlog/log.go
+++ b/vendor/github.com/prometheus/common/promlog/log.go
@@ -113,7 +113,7 @@ type Config struct {
 func New(config *Config) log.Logger {
 	var l log.Logger
 	if config.Format != nil && config.Format.s == "json" {
-		l = log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
+		l = log.NewJSONLogger(log.NewSyncWriter(os.Stderr))
 	} else {
 		l = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 	}


### PR DESCRIPTION
GKE is showing info logs as errors

This is by design
https://cloud.google.com/stackdriver/docs/solutions/gke/managing-logs#best_practices Use structured errors instead.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
