### PR TITLE
Updating the GitHub Action File

### DIFF
--- a/.github/workflows/prombench-gmp-collector.yml
+++ b/.github/workflows/prombench-gmp-collector.yml
@@ -33,8 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      contents: read
-      packages: read
     steps:
 
       - name: 'User Verification'
@@ -134,7 +132,7 @@ jobs:
           curl --silent -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/issues/${PR_NUMBER}/labels \
-            -d '{"labels":["prombench"]}' || true
+            -d '{"labels":["prombench"]}'
       
       - name: 'Check if the cluster exists'
         run: |

--- a/.github/workflows/prombench-gmp-collector.yml
+++ b/.github/workflows/prombench-gmp-collector.yml
@@ -33,6 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      contents: read
+      packages: read
     steps:
 
       - name: 'User Verification'
@@ -150,19 +152,19 @@ jobs:
       
       - name: 'Create the cluster'
         if: env.CREATE_CLUSTER == 'true'
-        uses: docker://saketjajoo/prombench:latest
+        uses: docker://ghcr.io/googlecloudplatform/prometheus-test-infra/prombench:latest
         with:
             args: make cluster_create;
       
       - name: 'Apply the cluster resources (to the main node)'
         if: env.CREATE_CLUSTER == 'true'
-        uses: docker://saketjajoo/prombench:latest
+        uses: docker://ghcr.io/googlecloudplatform/prometheus-test-infra/prombench:latest
         with:
             args: make cluster_resource_apply;
       
       - name: 'Create the nodes'
         if: env.CANCEL_BENCHMARK == 'false'
-        uses: docker://saketjajoo/prombench:latest
+        uses: docker://ghcr.io/googlecloudplatform/prometheus-test-infra/prombench:latest
         with:
             args: >-
               make clean;
@@ -171,13 +173,13 @@ jobs:
       
       - name: 'Apply the node resources (benchmark-related deployments)'
         if: env.CANCEL_BENCHMARK == 'false'
-        uses: docker://saketjajoo/prombench:latest
+        uses: docker://ghcr.io/googlecloudplatform/prometheus-test-infra/prombench:latest
         with:
             args: make resource_apply;
       
       - name: 'Delete the nodes'
         if: env.CANCEL_BENCHMARK == 'true'
-        uses: docker://saketjajoo/prombench:latest
+        uses: docker://ghcr.io/googlecloudplatform/prometheus-test-infra/prombench:latest
         with:
             args: make clean;
 

--- a/.github/workflows/prombench-gmp-collector.yml
+++ b/.github/workflows/prombench-gmp-collector.yml
@@ -171,3 +171,15 @@ jobs:
         uses: docker://saketjajoo/prombench:latest
         with:
             args: make clean;
+
+      - name: 'Post a comment to the PR upon cancelling the benchmark run'
+        if: env.CANCEL_BENCHMARK == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          COMMENT_MSG="Cancelling the benchmark run (for this PR)."
+
+          curl --silent -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/issues/${PR_NUMBER}/comments \
+            --data '{ "body": "'"${COMMENT_MSG}"'" }'

--- a/.github/workflows/prombench-gmp-collector.yml
+++ b/.github/workflows/prombench-gmp-collector.yml
@@ -71,9 +71,9 @@ jobs:
       
       - name: 'Set environment variables based on the triggered action'
         run: |
-          GMP_COLLECTOR_TAG=$(echo ${{ github.event.comment.body }} | head -n 1 | awk '{ print $2 }')
+          COLLECTOR_TAG_OR_CANCEL=$(echo ${{ github.event.comment.body }} | head -n 1 | awk '{ print $2 }')
 
-          if [ "${GMP_COLLECTOR_TAG}" == "cancel" ]
+          if [ "${COLLECTOR_TAG_OR_CANCEL}" == "cancel" ]
           then
             
             echo "Cancelling the benchmark run for PR #${PR_NUMBER}."
@@ -82,29 +82,29 @@ jobs:
 
           else
             
-            echo "GMP Collector Tag: ${GMP_COLLECTOR_TAG}"
+            echo "GMP Collector Tag: ${COLLECTOR_TAG_OR_CANCEL}"
 
             function get_default_collector_tag() {
               DEFAULT_COLLECTOR_TAG=$(gcloud container images list-tags ${PROMETHEUS_IMAGE_REPOSITORY} --sort-by=UPDATE_TIME,TAGS | tail -1 | awk '{ print $2 }')
             }
 
-            if [[ $GMP_COLLECTOR_TAG == '' ]]
+            if [[ $COLLECTOR_TAG_OR_CANCEL == '' ]]
             then
               echo "Since the collector version is missing, the latest one would be used."
               get_default_collector_tag
               echo "PROMETHEUS_IMAGE_VERSION=${DEFAULT_COLLECTOR_TAG}" >> $GITHUB_ENV
               export PROMETHEUS_IMAGE_VERSION="${DEFAULT_COLLECTOR_TAG}"
             else
-              GCLOUD_TAG=$(gcloud container images list-tags --filter="tags:${GMP_COLLECTOR_TAG}" --format=json ${PROMETHEUS_IMAGE_REPOSITORY})
+              GCLOUD_TAG=$(gcloud container images list-tags --filter="tags:${COLLECTOR_TAG_OR_CANCEL}" --format=json ${PROMETHEUS_IMAGE_REPOSITORY})
               if [[ "$GCLOUD_TAG" == "[]" ]]
               then
-                echo "The ${PROMETHEUS_IMAGE_REPOSITORY} image does not have the ${GMP_COLLECTOR_TAG} tag. Hence, this run will use the default latest tag."
+                echo "The ${PROMETHEUS_IMAGE_REPOSITORY} image does not have the ${COLLECTOR_TAG_OR_CANCEL} tag. Hence, this run will use the default latest tag."
                 DEFAULT_COLLECTOR_TAG=$(get_default_collector_tag)
                 echo "PROMETHEUS_IMAGE_VERSION=${DEFAULT_COLLECTOR_TAG}" >> $GITHUB_ENV
                 export PROMETHEUS_IMAGE_VERSION="${DEFAULT_COLLECTOR_TAG}"
               else
-                echo "PROMETHEUS_IMAGE_VERSION=${GMP_COLLECTOR_TAG}" >> $GITHUB_ENV
-                export PROMETHEUS_IMAGE_VERSION="${GMP_COLLECTOR_TAG}"
+                echo "PROMETHEUS_IMAGE_VERSION=${COLLECTOR_TAG_OR_CANCEL}" >> $GITHUB_ENV
+                export PROMETHEUS_IMAGE_VERSION="${COLLECTOR_TAG_OR_CANCEL}"
               fi
             fi
             

--- a/.github/workflows/prombench-gmp-collector.yml
+++ b/.github/workflows/prombench-gmp-collector.yml
@@ -1,9 +1,6 @@
 name: "Run Prombench"
 
 on:
-  push:
-    tags:
-      - 'v*-gmp.*'
   issue_comment:                                 
     types:
       - created

--- a/.github/workflows/prombench-gmp-collector.yml
+++ b/.github/workflows/prombench-gmp-collector.yml
@@ -38,7 +38,7 @@ jobs:
       pull-requests: write
     steps:
 
-      - name: verify_user
+      - name: 'User Verification'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENTER: ${{ github.event.comment.user.login }}
@@ -70,7 +70,7 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v1'
 
       
-      - name: check_benchmark_trigger_action
+      - name: 'Set environment variables based on the triggered action'
         run: |
           GMP_COLLECTOR_TAG=$(echo ${{ github.event.comment.body }} | head -n 1 | awk '{ print $2 }')
 
@@ -113,7 +113,7 @@ jobs:
 
           fi
 
-      - name: post_comment_to_pr
+      - name: 'Post a comment to the PR upon triggering the benchmark run'
         if: env.CANCEL_BENCHMARK == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -128,7 +128,7 @@ jobs:
             --data '{ "body": "'"${COMMENT_MSG}"'" }'
 
       
-      - name: check_cluster_existance
+      - name: 'Check if the cluster exists'
         run: |
           if RETURN=$(gcloud container clusters describe "${CLUSTER_NAME}" --project="${GKE_PROJECT_ID}" --location="${ZONE}" >/dev/null 2>&1)
           then
@@ -142,19 +142,19 @@ jobs:
           fi
 
       
-      - name: cluster_create
+      - name: 'Create the cluster'
         if: env.CREATE_CLUSTER == 'true'
         uses: docker://saketjajoo/prombench:latest
         with:
             args: make cluster_create;
       
-      - name: cluster_resource_apply
+      - name: 'Apply the cluster resources (to the main node)'
         if: env.CREATE_CLUSTER == 'true'
         uses: docker://saketjajoo/prombench:latest
         with:
             args: make cluster_resource_apply;
       
-      - name: node_create
+      - name: 'Create the nodes'
         if: env.CANCEL_BENCHMARK == 'false'
         uses: docker://saketjajoo/prombench:latest
         with:
@@ -163,13 +163,13 @@ jobs:
               until make all_nodes_deleted; do echo "Waiting for nodepools to be deleted"; sleep 10; done;
               make node_create;
       
-      - name: node_resource_apply
+      - name: 'Apply the node resources (benchmark-related deployments)'
         if: env.CANCEL_BENCHMARK == 'false'
         uses: docker://saketjajoo/prombench:latest
         with:
             args: make resource_apply;
       
-      - name: node_delete
+      - name: 'Delete the nodes'
         if: env.CANCEL_BENCHMARK == 'true'
         uses: docker://saketjajoo/prombench:latest
         with:

--- a/.github/workflows/prombench-gmp-collector.yml
+++ b/.github/workflows/prombench-gmp-collector.yml
@@ -123,7 +123,16 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/issues/${PR_NUMBER}/comments \
             --data '{ "body": "'"${COMMENT_MSG}"'" }'
-
+          
+      - name: 'Adding the prombench label to the PR'
+        if: env.CANCEL_BENCHMARK == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl --silent -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/issues/${PR_NUMBER}/labels \
+            -d '{"labels":["prombench"]}' || true
       
       - name: 'Check if the cluster exists'
         run: |


### PR DESCRIPTION
This PR updates the GH Actions file to have the following changes:
- Renaming the steps in the workflow to make it more meaningful (code readability).
- Disabling prombench trigger on release cut (prombench now works only upon commenting on a PR).
- Adding comments to a PR when a prombench run is cancelled.
- Adding labels to a PR when a prombench run is triggered.
- Fixing the docker image URLs to point to the GHCR repo instead of a personal dockerhub account.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
