### PR TITLE
Adding GITHUB_TOKEN and its associated permissions

### DIFF
--- a/.github/workflows/prombench-gmp-collector.yml
+++ b/.github/workflows/prombench-gmp-collector.yml
@@ -33,6 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      contents: read
+      packages: read
     steps:
 
       - name: 'User Verification'
@@ -150,18 +152,24 @@ jobs:
       
       - name: 'Create the cluster'
         if: env.CREATE_CLUSTER == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: docker://ghcr.io/googlecloudplatform/prometheus-test-infra/prombench:latest
         with:
             args: make cluster_create;
       
       - name: 'Apply the cluster resources (to the main node)'
         if: env.CREATE_CLUSTER == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: docker://ghcr.io/googlecloudplatform/prometheus-test-infra/prombench:latest
         with:
             args: make cluster_resource_apply;
       
       - name: 'Create the nodes'
         if: env.CANCEL_BENCHMARK == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: docker://ghcr.io/googlecloudplatform/prometheus-test-infra/prombench:latest
         with:
             args: >-
@@ -171,12 +179,16 @@ jobs:
       
       - name: 'Apply the node resources (benchmark-related deployments)'
         if: env.CANCEL_BENCHMARK == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: docker://ghcr.io/googlecloudplatform/prometheus-test-infra/prombench:latest
         with:
             args: make resource_apply;
       
       - name: 'Delete the nodes'
         if: env.CANCEL_BENCHMARK == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: docker://ghcr.io/googlecloudplatform/prometheus-test-infra/prombench:latest
         with:
             args: make clean;


### PR DESCRIPTION
Adding GITHUB_TOKEN and its associated permissions so that Actions can authenticate to GHCR and pull the image.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
