### PR TITLE
Using the AUTH_FILE parameter instead of GOOGLE_APPLICATION_CREDENTIALS in Prombench to make it consistent with upstream.

### DIFF
--- a/.cloudbuild/prombench.yaml
+++ b/.cloudbuild/prombench.yaml
@@ -20,7 +20,7 @@ steps:
       GITHUB_ORG=$(echo "${_GIT_REPO}" | cut -d'/' -f1) # GoogleCloudPlatform
       GITHUB_REPO=$(echo "${_GIT_REPO}" | cut -d'/' -f2) # prometheus
 
-      echo "GOOGLE_APPLICATION_CREDENTIALS=/home/adc.json" >> /workspace/PROMBENCH_ENV_FILE
+      echo "AUTH_FILE=/home/adc.json" >> /workspace/PROMBENCH_ENV_FILE
       echo "CLUSTER_NAME=${CLUSTER_NAME}" >> /workspace/PROMBENCH_ENV_FILE
       echo "DOMAIN_NAME=${DOMAIN_NAME}" >> /workspace/PROMBENCH_ENV_FILE
       echo "GITHUB_ORG=${GITHUB_ORG}" >> /workspace/PROMBENCH_ENV_FILE


### PR DESCRIPTION
Reference PR: https://github.com/GoogleCloudPlatform/prometheus-test-infra/pull/23

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
