### PR TITLE
Update Debian to latest stable release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_BUILD_NODEJS=launcher.gcr.io/google/nodejs
-ARG IMAGE_BUILD_GO=golang:1.20-buster
-ARG IMAGE_BASE_DEBUG=gcr.io/distroless/static-debian10:debug
-ARG IMAGE_BASE=gcr.io/distroless/static-debian10
+ARG IMAGE_BUILD_GO=golang:1.20-bookworm
+ARG IMAGE_BASE_DEBUG=gcr.io/distroless/static-debian12:debug
+ARG IMAGE_BASE=gcr.io/distroless/static-debian12
 
 FROM ${IMAGE_BUILD_GO} AS gobase
 


### PR DESCRIPTION
Need to update to golang:1.20.7 to fix security vulnerabilities.

golang 1.20-buster supports only until golang 1.20.5, it's also the oldoldstable of debian. 

golang 1.20-bookworm is the current stable release. https://wiki.debian.org/DebianReleases