### PR TITLE
scrape_test: add scrape offset in test scraper to avoid race

### DIFF
--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -647,6 +647,10 @@ func TestScrapeLoopStopBeforeRun(t *testing.T) {
 		nil,
 	)
 
+	// The loop must terminate during the initial offset if the context
+	// is canceled.
+	scraper.offsetDur = time.Hour
+
 	// The scrape pool synchronizes on stopping scrape loops. However, new scrape
 	// loops are started asynchronously. Thus it's possible, that a loop is stopped
 	// again before having started properly.


### PR DESCRIPTION
This change adds an offset to the test scraper so a scrape is not initiated when the context is cancelled. Without this change, there was a race between the context cancellation and the scrape jitter wait and this change fixes that.

Can verify using:
go test -run ^TestScrapeLoopStopBeforeRun$ github.com/prometheus/prometheus/scrape -race -count 1000

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
