### PR TITLE
Native Kubernetes secrets for authorization

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -52,6 +52,8 @@ import (
 	"k8s.io/klog"
 	klogv2 "k8s.io/klog/v2"
 
+	common_config "github.com/prometheus/common/config"
+
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/legacymanager"
@@ -66,6 +68,7 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/scrape"
+	"github.com/prometheus/prometheus/secrets/kubernetes"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/tracing"
@@ -152,6 +155,7 @@ type flagConfig struct {
 	enableNewSDManager         bool
 	enablePerStepStats         bool
 	enableAutoGOMAXPROCS       bool
+	enableKubeSecretProvider   bool
 
 	prometheusURL   string
 	corsRegexString string
@@ -199,6 +203,9 @@ func (c *flagConfig) setFeatureListOptions(logger log.Logger) error {
 				c.tsdb.EnableNativeHistograms = true
 				c.scrape.EnableProtobufNegotiation = true
 				level.Info(logger).Log("msg", "Experimental native histogram support enabled.")
+			case "kubernetes-secret-provider":
+				c.enableKubeSecretProvider = true
+				level.Info(logger).Log("msg", "Experimental Kubernetes secret provider enabled.")
 			case "":
 				continue
 			case "promql-at-modifier", "promql-negative-offset":
@@ -591,6 +598,8 @@ func main() {
 		ctxWeb, cancelWeb = context.WithCancel(context.Background())
 		ctxRule           = context.Background()
 
+		ctxSecrets = context.Background()
+
 		notifierManager = notifier.NewManager(&cfg.notifier, log.With(logger, "component", "notifier"))
 
 		ctxScrape, cancelScrape = context.WithCancel(context.Background())
@@ -608,6 +617,18 @@ func main() {
 		discoveryManagerScrape = legacymanager.NewManager(ctxScrape, log.With(logger, "component", "discovery manager scrape"), legacymanager.Name("scrape"))
 		discoveryManagerNotify = legacymanager.NewManager(ctxNotify, log.With(logger, "component", "discovery manager notify"), legacymanager.Name("notify"))
 	}
+
+	var secretManager *kubernetes.Manager
+	if cfg.enableKubeSecretProvider {
+		secretManager = kubernetes.NewManager(
+			ctxSecrets,
+			log.With(logger, "component", "secret manager"),
+			prometheus.DefaultRegisterer,
+		)
+		defer secretManager.Close(prometheus.DefaultRegisterer)
+	}
+
+	cfg.scrape.HTTPClientOptions = append(cfg.scrape.HTTPClientOptions, common_config.WithSecretManager(secretManager))
 
 	var (
 		scrapeManager  = scrape.NewManager(&cfg.scrape, log.With(logger, "component", "scrape manager"), fanoutStorage)
@@ -755,6 +776,20 @@ func main() {
 					c[v.JobName] = v.ServiceDiscoveryConfigs
 				}
 				return discoveryManagerScrape.ApplyConfig(c)
+			},
+		}, {
+			name: "secret",
+			reloader: func(cfg *config.Config) error {
+				if secretManager == nil {
+					if len(cfg.SecretConfigs) > 0 {
+						return errors.New("secret providers are disabled")
+					}
+					return nil
+				}
+				kConfig := kubernetes.WatchSPConfig{
+					ClientConfig: cfg.ClientConfig,
+				}
+				return secretManager.ApplyConfig(ctxSecrets, &kConfig, cfg.SecretConfigs)
 			},
 		}, {
 			name:     "notify",

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,7 @@ import (
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/prometheus/prometheus/secrets/kubernetes"
 )
 
 var (
@@ -223,6 +224,10 @@ type Config struct {
 	ScrapeConfigs     []*ScrapeConfig `yaml:"scrape_configs,omitempty"`
 	StorageConfig     StorageConfig   `yaml:"storage,omitempty"`
 	TracingConfig     TracingConfig   `yaml:"tracing,omitempty"`
+
+	// Secret management:
+	kubernetes.ClientConfig  `yaml:"kubernetes_sp_config,omitempty"`
+	kubernetes.SecretConfigs `yaml:"kubernetes_secrets,omitempty"`
 
 	RemoteWriteConfigs []*RemoteWriteConfig `yaml:"remote_write,omitempty"`
 	RemoteReadConfigs  []*RemoteReadConfig  `yaml:"remote_read,omitempty"`

--- a/go.mod
+++ b/go.mod
@@ -196,7 +196,7 @@ require (
 )
 
 replace (
-	github.com/prometheus/common => github.com/TheSpiritXIII/prometheus-common v0.43.0-gmp.0
+	github.com/prometheus/common => github.com/TheSpiritXIII/prometheus-common v0.43.0-gmp.1
 	k8s.io/klog => github.com/simonpasquier/klog-gokit v0.3.0
 	k8s.io/klog/v2 => github.com/simonpasquier/klog-gokit/v3 v3.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
-github.com/TheSpiritXIII/prometheus-common v0.43.0-gmp.0 h1:cNY6NCb1jDAU4xuZJnLRF51+eY04gZ3btz0Hu40VOaY=
-github.com/TheSpiritXIII/prometheus-common v0.43.0-gmp.0/go.mod h1:NCvr5cQIh3Y/gy73/RdVtC9r8xxrxwJnB+2lB3BxrFc=
+github.com/TheSpiritXIII/prometheus-common v0.43.0-gmp.1 h1:IrWzg0hOrcv1nGFRI8XfOiLMVHf/lJA+igby5drlL5w=
+github.com/TheSpiritXIII/prometheus-common v0.43.0-gmp.1/go.mod h1:MHfkLrr2VWqzh2yvwSrzxbB48Wg3bKse6G0drrFBPqA=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/alecthomas/kingpin/v2 v2.3.2/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=

--- a/secrets/kubernetes/config.go
+++ b/secrets/kubernetes/config.go
@@ -1,0 +1,51 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus/prometheus/secrets"
+)
+
+type SecretConfigs []secrets.SecretConfig[SecretConfig]
+
+type Manager struct {
+	ctx      context.Context
+	provider secrets.ProviderManager[SecretConfig]
+}
+
+func NewManager(ctx context.Context, log log.Logger, reg prometheus.Registerer) *Manager {
+	return &Manager{
+		ctx:      ctx,
+		provider: secrets.NewProviderManager[SecretConfig](ctx, reg),
+	}
+}
+
+// ApplyConfig checks if secret provider with supplied config is already running and keeps them as is.
+// Remaining providers are then stopped and new required providers are started using the provided config.
+func (m *Manager) ApplyConfig(ctx context.Context, providerConfig secrets.Config[SecretConfig], configs SecretConfigs) error {
+	return m.provider.ApplyConfig(ctx, providerConfig, configs)
+}
+
+func (m *Manager) Fetch(ctx context.Context, name string) (string, error) {
+	return m.provider.Fetch(m.ctx, name)
+}
+
+func (m *Manager) Close(reg prometheus.Registerer) {
+	m.provider.Close(reg)
+}

--- a/secrets/kubernetes/kubernetes.go
+++ b/secrets/kubernetes/kubernetes.go
@@ -1,0 +1,81 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"fmt"
+
+	"github.com/prometheus/common/config"
+	"github.com/prometheus/common/version"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// HTTP header.
+var userAgent = fmt.Sprintf("Prometheus/%s", version.Version)
+
+type SecretConfig struct {
+	Namespace string `yaml:"namespace"`
+	Name      string `yaml:"name"`
+	Key       string `yaml:"key"`
+}
+
+func (c *SecretConfig) objectKey() types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: c.Namespace,
+		Name:      c.Name,
+	}
+}
+
+func getKey(s *corev1.Secret, key string) (string, error) {
+	if value, ok := s.Data[key]; ok {
+		return string(value), nil
+	}
+	if value, ok := s.StringData[key]; ok {
+		return value, nil
+	}
+	return "", fmt.Errorf("secret %s/%s does not contain key: %s", s.Namespace, s.Name, key)
+}
+
+type ClientConfig struct {
+	APIServer  config.URL `yaml:"api_server,omitempty"`
+	KubeConfig string     `yaml:"kubeconfig_file,omitempty"`
+}
+
+// New creates a new Kubernetes discovery for the given role.
+func (c *ClientConfig) client() (kubernetes.Interface, error) {
+	var restClient *rest.Config
+	switch {
+	case c.KubeConfig != "":
+		var err error
+		restClient, err = clientcmd.BuildConfigFromFlags("", c.KubeConfig)
+		if err != nil {
+			return nil, err
+		}
+	case c.APIServer.URL == nil:
+		var err error
+		restClient, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	restClient.UserAgent = userAgent
+	restClient.ContentType = "application/vnd.kubernetes.protobuf"
+
+	return kubernetes.NewForConfig(restClient)
+}

--- a/secrets/kubernetes/kubernetes_test.go
+++ b/secrets/kubernetes/kubernetes_test.go
@@ -1,0 +1,550 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/prometheus/prometheus/secrets"
+)
+
+func toSecretConfig(s *corev1.Secret, key string) *SecretConfig {
+	return &SecretConfig{
+		Namespace: s.Namespace,
+		Name:      s.Name,
+		Key:       key,
+	}
+}
+
+func deleteKey(s *corev1.Secret, key string) {
+	delete(s.Data, key)
+	delete(s.StringData, key)
+}
+
+func updateKey(s *corev1.Secret, key, value string) {
+	if _, ok := s.Data[key]; ok {
+		s.Data[key] = []byte(value)
+		return
+	}
+	if _, ok := s.StringData[key]; ok {
+		s.StringData[key] = value
+		return
+	}
+	panic(fmt.Errorf("invalid key %q in secret: %s/%s", key, s.Namespace, s.Name))
+}
+
+func copyKey(s *corev1.Secret, keyFrom, keyTo string) {
+	if _, ok := s.Data[keyFrom]; ok {
+		s.Data[keyTo] = s.Data[keyFrom]
+		return
+	}
+	if _, ok := s.StringData[keyFrom]; ok {
+		s.StringData[keyTo] = s.StringData[keyFrom]
+		return
+	}
+	panic(fmt.Errorf("invalid key %q in secret: %s/%s", keyFrom, s.Namespace, s.Name))
+}
+
+type testCase struct {
+	description string
+	test        func(ctx context.Context, c *fake.Clientset, provider secrets.Provider[SecretConfig])
+}
+
+type entry struct {
+	key   string
+	value string
+}
+
+type testCategory struct {
+	name    string
+	secret  *corev1.Secret
+	entries []entry
+}
+
+// Simpler re-implementation of the same method in the k8s library.
+func pollUntilContextTimeout(ctx context.Context, interval, timeout time.Duration, condition func(context.Context) (done bool, err error)) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	timer := time.NewTicker(interval)
+	for {
+		select {
+		case <-timeoutCtx.Done():
+			return timeoutCtx.Err()
+		case <-timer.C:
+			ok, err := condition(timeoutCtx)
+			if err != nil {
+				return err
+			}
+			if ok {
+				return nil
+			}
+		}
+	}
+}
+
+func requireFetchEquals(t testing.TB, ctx context.Context, s secrets.Secret, expected string) {
+	var err error
+	pollErr := pollUntilContextTimeout(ctx, time.Millisecond, 10*time.Second, func(ctx context.Context) (bool, error) {
+		var val string
+		val, err = s.Fetch(ctx)
+		if err != nil {
+			err = fmt.Errorf("expected nil error but received: %w", err)
+			return false, nil
+		}
+		if expected != val {
+			err = fmt.Errorf("expected value %q but received %q", expected, val)
+			return false, nil
+		}
+		return true, nil
+	})
+	if pollErr != nil {
+		if errors.Is(pollErr, context.DeadlineExceeded) && err != nil {
+			pollErr = err
+		}
+		t.Fatal(pollErr)
+	}
+}
+
+func requireFetchFail(t testing.TB, ctx context.Context, s secrets.Secret, expected error) {
+	var err error
+	pollErr := pollUntilContextTimeout(ctx, time.Millisecond, 10*time.Second, func(ctx context.Context) (bool, error) {
+		var val string
+		val, err = s.Fetch(ctx)
+		if val != "" {
+			err = fmt.Errorf("expected empty value but received %q", val)
+			return false, nil
+		}
+		if expected.Error() != err.Error() {
+			err = fmt.Errorf("expected error %q but received %q", expected, err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if pollErr != nil {
+		if errors.Is(pollErr, context.DeadlineExceeded) && err != nil {
+			pollErr = err
+		}
+		t.Fatal(pollErr)
+	}
+}
+
+func TestProvider(t *testing.T) {
+	validEmptySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns1",
+			Name:      "s1",
+		},
+	}
+	validBinarySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns1",
+			Name:      "s2",
+		},
+		Data: map[string][]byte{
+			"k1": []byte("Hello world!"),
+			"k2": []byte("xyz"),
+			"k3": []byte("abc"),
+		},
+	}
+	validStringSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns2",
+			Name:      "s1",
+		},
+		StringData: map[string]string{
+			"foo":   "bar",
+			"alpha": "bravo",
+		},
+	}
+	validMixedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns3",
+			Name:      "s2",
+		},
+		Data: map[string][]byte{
+			"red": []byte("green"),
+		},
+		StringData: map[string]string{
+			"orange": "blue",
+		},
+	}
+
+	testCasesFor := func(main testCategory, others ...testCategory) []testCase {
+		testCases := []testCase{
+			{
+				description: fmt.Sprintf("remove untracked %s secret", main.name),
+				test: func(ctx context.Context, c *fake.Clientset, provider secrets.Provider[SecretConfig]) {
+					err := provider.Remove(ctx, toSecretConfig(main.secret, main.entries[0].key))
+					require.NoError(t, err)
+				},
+			},
+			{
+				description: fmt.Sprintf("remove tracked %s secret", main.name),
+				test: func(ctx context.Context, c *fake.Clientset, provider secrets.Provider[SecretConfig]) {
+					s, err := provider.Add(ctx, toSecretConfig(main.secret, main.entries[0].key))
+					require.NoError(t, err)
+					requireFetchEquals(t, ctx, s, main.entries[0].value)
+
+					err = provider.Remove(ctx, toSecretConfig(main.secret, main.entries[0].key))
+					require.NoError(t, err)
+
+					// Attempt to remove twice. Second time does nothing.
+					err = provider.Remove(ctx, toSecretConfig(main.secret, main.entries[0].key))
+					require.NoError(t, err)
+				},
+			},
+			{
+				description: fmt.Sprintf("valid %s delete key", main.name),
+				test: func(ctx context.Context, c *fake.Clientset, provider secrets.Provider[SecretConfig]) {
+					key := main.entries[0].key
+					s, err := provider.Add(ctx, toSecretConfig(main.secret, key))
+					require.NoError(t, err)
+					requireFetchEquals(t, ctx, s, main.entries[0].value)
+
+					secret := main.secret.DeepCopy()
+					deleteKey(secret, key)
+					_, err = c.CoreV1().Secrets(secret.Namespace).Update(ctx, secret, metav1.UpdateOptions{})
+					require.NoError(t, err)
+
+					requireFetchFail(t, ctx, s, fmt.Errorf("secret %s/%s does not contain key: %s", main.secret.Namespace, main.secret.Name, key))
+
+					err = provider.Remove(ctx, toSecretConfig(main.secret, key))
+					require.NoError(t, err)
+				},
+			},
+			{
+				description: fmt.Sprintf("valid %s delete secret", main.name),
+				test: func(ctx context.Context, c *fake.Clientset, provider secrets.Provider[SecretConfig]) {
+					key := main.entries[0].key
+					s, err := provider.Add(ctx, toSecretConfig(main.secret, key))
+					require.NoError(t, err)
+					requireFetchEquals(t, ctx, s, main.entries[0].value)
+
+					err = c.CoreV1().Secrets(main.secret.Namespace).Delete(ctx, main.secret.Name, metav1.DeleteOptions{})
+					require.NoError(t, err)
+
+					requireFetchFail(t, ctx, s, fmt.Errorf("secret %s/%s not found", main.secret.Namespace, main.secret.Name))
+
+					err = provider.Remove(ctx, toSecretConfig(main.secret, key))
+					require.NoError(t, err)
+				},
+			},
+			{
+				description: fmt.Sprintf("valid %s update value", main.name),
+				test: func(ctx context.Context, c *fake.Clientset, provider secrets.Provider[SecretConfig]) {
+					key := main.entries[0].key
+					s, err := provider.Add(ctx, toSecretConfig(main.secret, key))
+					require.NoError(t, err)
+					requireFetchEquals(t, ctx, s, main.entries[0].value)
+
+					secret := main.secret.DeepCopy()
+					updateKey(secret, key, "Goodbye")
+					_, err = c.CoreV1().Secrets(secret.Namespace).Update(ctx, secret, metav1.UpdateOptions{})
+					require.NoError(t, err)
+
+					requireFetchEquals(t, ctx, s, "Goodbye")
+
+					err = provider.Remove(ctx, toSecretConfig(main.secret, key))
+					require.NoError(t, err)
+				},
+			},
+			{
+				description: fmt.Sprintf("valid %s update valid key", main.name),
+				test: func(ctx context.Context, c *fake.Clientset, provider secrets.Provider[SecretConfig]) {
+					keyFrom := main.entries[0].key
+					s, err := provider.Add(ctx, toSecretConfig(main.secret, keyFrom))
+					require.NoError(t, err)
+					requireFetchEquals(t, ctx, s, main.entries[0].value)
+
+					keyTo := main.entries[1].key
+					s, err = provider.Update(ctx, toSecretConfig(main.secret, keyFrom), toSecretConfig(main.secret, keyTo))
+					require.NoError(t, err)
+					requireFetchEquals(t, ctx, s, main.entries[1].value)
+
+					// Update original key.
+					secret := main.secret.DeepCopy()
+					updateKey(secret, keyFrom, "Goodbye")
+					_, err = c.CoreV1().Secrets(secret.Namespace).Update(ctx, secret, metav1.UpdateOptions{})
+					require.NoError(t, err)
+
+					requireFetchEquals(t, ctx, s, main.entries[1].value)
+
+					// Update new key.
+					updateKey(secret, keyTo, "Sayonara")
+					_, err = c.CoreV1().Secrets(secret.Namespace).Update(ctx, secret, metav1.UpdateOptions{})
+					require.NoError(t, err)
+
+					requireFetchEquals(t, ctx, s, "Sayonara")
+
+					err = provider.Remove(ctx, toSecretConfig(main.secret, keyTo))
+					require.NoError(t, err)
+				},
+			},
+			{
+				description: fmt.Sprintf("valid %s update invalid key", main.name),
+				test: func(ctx context.Context, c *fake.Clientset, provider secrets.Provider[SecretConfig]) {
+					key := main.entries[0].key
+					s, err := provider.Add(ctx, toSecretConfig(main.secret, key))
+					require.NoError(t, err)
+					requireFetchEquals(t, ctx, s, main.entries[0].value)
+
+					s, err = provider.Update(ctx, toSecretConfig(main.secret, key), toSecretConfig(main.secret, "x"))
+					require.NoError(t, err)
+					requireFetchFail(t, ctx, s, fmt.Errorf("secret %s/%s does not contain key: x", main.secret.Namespace, main.secret.Name))
+
+					err = provider.Remove(ctx, toSecretConfig(main.secret, key))
+					require.NoError(t, err)
+				},
+			},
+			{
+				description: fmt.Sprintf("valid %s update invalid secret", main.name),
+				test: func(ctx context.Context, c *fake.Clientset, provider secrets.Provider[SecretConfig]) {
+					key := main.entries[0].key
+					s, err := provider.Add(ctx, toSecretConfig(main.secret, key))
+					require.NoError(t, err)
+					requireFetchEquals(t, ctx, s, main.entries[0].value)
+
+					s, err = provider.Update(ctx, toSecretConfig(main.secret, key), &SecretConfig{Namespace: "x", Name: "y", Key: "z"})
+					require.NoError(t, err)
+					requireFetchFail(t, ctx, s, fmt.Errorf("secret x/y not found"))
+
+					err = provider.Remove(ctx, &SecretConfig{Namespace: "x", Name: "y", Key: "z"})
+					require.NoError(t, err)
+				},
+			},
+			{
+				description: fmt.Sprintf("invalid %s create key", main.name),
+				test: func(ctx context.Context, c *fake.Clientset, provider secrets.Provider[SecretConfig]) {
+					key := "kn"
+					s, err := provider.Add(ctx, toSecretConfig(main.secret, key))
+					require.NoError(t, err)
+					requireFetchFail(t, ctx, s, fmt.Errorf("secret %s/%s does not contain key: %s", main.secret.Namespace, main.secret.Name, key))
+
+					secret := main.secret.DeepCopy()
+					copyKey(secret, main.entries[0].key, key)
+					updateKey(secret, key, "Goodbye")
+					_, err = c.CoreV1().Secrets(secret.Namespace).Update(ctx, secret, metav1.UpdateOptions{})
+					require.NoError(t, err)
+
+					requireFetchEquals(t, ctx, s, "Goodbye")
+
+					err = provider.Remove(ctx, toSecretConfig(main.secret, key))
+					require.NoError(t, err)
+				},
+			},
+			{
+				description: fmt.Sprintf("invalid %s create secret", main.name),
+				test: func(ctx context.Context, c *fake.Clientset, provider secrets.Provider[SecretConfig]) {
+					err := c.CoreV1().Secrets(main.secret.Namespace).Delete(ctx, main.secret.Name, metav1.DeleteOptions{})
+					require.NoError(t, err)
+
+					key := main.entries[0].key
+					s, err := provider.Add(ctx, toSecretConfig(main.secret, key))
+					require.NoError(t, err)
+					requireFetchFail(t, ctx, s, fmt.Errorf("secret %s/%s not found", main.secret.Namespace, main.secret.Name))
+
+					secret := main.secret.DeepCopy()
+					updateKey(secret, key, "Goodbye")
+					_, err = c.CoreV1().Secrets(secret.Namespace).Create(ctx, secret, metav1.CreateOptions{})
+					require.NoError(t, err)
+
+					requireFetchEquals(t, ctx, s, "Goodbye")
+
+					err = provider.Remove(ctx, toSecretConfig(main.secret, key))
+					require.NoError(t, err)
+				},
+			},
+			{
+				description: fmt.Sprintf("invalid %s update valid key", main.name),
+				test: func(ctx context.Context, c *fake.Clientset, provider secrets.Provider[SecretConfig]) {
+					keyFrom := "kn1"
+					s, err := provider.Add(ctx, toSecretConfig(main.secret, keyFrom))
+					require.NoError(t, err)
+					requireFetchFail(t, ctx, s, fmt.Errorf("secret %s/%s does not contain key: %s", main.secret.Namespace, main.secret.Name, keyFrom))
+
+					keyTo := "kn2"
+					s, err = provider.Update(ctx, toSecretConfig(main.secret, keyFrom), toSecretConfig(main.secret, keyTo))
+					require.NoError(t, err)
+					requireFetchFail(t, ctx, s, fmt.Errorf("secret %s/%s does not contain key: %s", main.secret.Namespace, main.secret.Name, keyTo))
+
+					err = provider.Remove(ctx, toSecretConfig(main.secret, keyTo))
+					require.NoError(t, err)
+				},
+			},
+			{
+				description: fmt.Sprintf("invalid update valid %s secret", main.name),
+				test: func(ctx context.Context, c *fake.Clientset, provider secrets.Provider[SecretConfig]) {
+					s, err := provider.Add(ctx, &SecretConfig{Namespace: "x", Name: "y", Key: "z"})
+					require.NoError(t, err)
+					requireFetchFail(t, ctx, s, errors.New("secret x/y not found"))
+
+					keyTo := main.entries[0].key
+					s, err = provider.Update(ctx, &SecretConfig{Namespace: "x", Name: "y", Key: "z"}, toSecretConfig(main.secret, keyTo))
+					require.NoError(t, err)
+					requireFetchEquals(t, ctx, s, main.entries[0].value)
+
+					err = provider.Remove(ctx, toSecretConfig(main.secret, keyTo))
+					require.NoError(t, err)
+				},
+			},
+			{
+				description: fmt.Sprintf("invalid %s update invalid key", main.name),
+				test: func(ctx context.Context, c *fake.Clientset, provider secrets.Provider[SecretConfig]) {
+					keyFrom := "kn"
+					s, err := provider.Add(ctx, toSecretConfig(main.secret, keyFrom))
+					require.NoError(t, err)
+					requireFetchFail(t, ctx, s, fmt.Errorf("secret %s/%s does not contain key: %s", main.secret.Namespace, main.secret.Name, keyFrom))
+
+					keyTo := main.entries[0].key
+					s, err = provider.Update(ctx, toSecretConfig(main.secret, keyFrom), toSecretConfig(main.secret, keyTo))
+					require.NoError(t, err)
+					requireFetchEquals(t, ctx, s, main.entries[0].value)
+
+					err = provider.Remove(ctx, toSecretConfig(main.secret, keyTo))
+					require.NoError(t, err)
+				},
+			},
+			{
+				description: fmt.Sprintf("invalid %s update invalid secret", main.name),
+				test: func(ctx context.Context, c *fake.Clientset, provider secrets.Provider[SecretConfig]) {
+					s, err := provider.Add(ctx, &SecretConfig{Namespace: "x", Name: "y", Key: "z"})
+					require.NoError(t, err)
+					requireFetchFail(t, ctx, s, errors.New("secret x/y not found"))
+
+					s, err = provider.Update(ctx, &SecretConfig{Namespace: "x", Name: "y", Key: "z"}, &SecretConfig{Namespace: "a", Name: "b", Key: "c"})
+					require.NoError(t, err)
+					requireFetchFail(t, ctx, s, errors.New("secret a/b not found"))
+
+					err = provider.Remove(ctx, &SecretConfig{Namespace: "a", Name: "b", Key: "c"})
+					require.NoError(t, err)
+				},
+			},
+		}
+		for _, other := range others {
+			testCases = append(
+				testCases,
+				testCase{
+					description: fmt.Sprintf("valid %s update valid %s secret", main.name, other.name),
+					test: func(ctx context.Context, c *fake.Clientset, provider secrets.Provider[SecretConfig]) {
+						keyFrom := main.entries[0].key
+						s, err := provider.Add(ctx, toSecretConfig(main.secret, keyFrom))
+						require.NoError(t, err)
+						requireFetchEquals(t, ctx, s, main.entries[0].value)
+
+						keyTo := other.entries[0].key
+						s, err = provider.Update(ctx, toSecretConfig(main.secret, keyFrom), toSecretConfig(other.secret, keyTo))
+						require.NoError(t, err)
+						requireFetchEquals(t, ctx, s, other.entries[0].value)
+
+						// Update original secret.
+						secret := main.secret.DeepCopy()
+						updateKey(secret, keyFrom, "Goodbye")
+						_, err = c.CoreV1().Secrets(secret.Namespace).Update(ctx, secret, metav1.UpdateOptions{})
+						require.NoError(t, err)
+
+						requireFetchEquals(t, ctx, s, other.entries[0].value)
+
+						// Update new secret.
+						secret = other.secret.DeepCopy()
+						updateKey(secret, keyTo, "Sayonara")
+						_, err = c.CoreV1().Secrets(secret.Namespace).Update(ctx, secret, metav1.UpdateOptions{})
+						require.NoError(t, err)
+
+						requireFetchEquals(t, ctx, s, "Sayonara")
+
+						err = provider.Remove(ctx, toSecretConfig(other.secret, keyTo))
+						require.NoError(t, err)
+					},
+				},
+			)
+		}
+		return testCases
+	}
+	typeBinary := testCategory{
+		name:   "binary",
+		secret: validBinarySecret,
+		entries: []entry{
+			{"k1", "Hello world!"},
+			{"k2", "xyz"},
+		},
+	}
+	typeString := testCategory{
+		name:   "string",
+		secret: validStringSecret,
+		entries: []entry{
+			{"foo", "bar"},
+			{"alpha", "bravo"},
+		},
+	}
+	typeMixedString := testCategory{
+		name:   "mixed (string)",
+		secret: validMixedSecret,
+		entries: []entry{
+			{"orange", "blue"},
+			{"red", "green"},
+		},
+	}
+	typeMixedBinary := testCategory{
+		name:   "mixed (binary)",
+		secret: validMixedSecret,
+		entries: []entry{
+			{"red", "green"},
+			{"orange", "blue"},
+		},
+	}
+
+	testCases := []testCase{
+		{
+			description: "add secret with no keys",
+			test: func(ctx context.Context, c *fake.Clientset, provider secrets.Provider[SecretConfig]) {
+				err := provider.Remove(ctx, toSecretConfig(validEmptySecret, "k1"))
+				require.NoError(t, err)
+			},
+		},
+	}
+	testCases = append(testCases, testCasesFor(typeBinary, typeString, typeMixedBinary, typeMixedString)...)
+	testCases = append(testCases, testCasesFor(typeString, typeBinary, typeMixedBinary, typeMixedString)...)
+	testCases = append(testCases, testCasesFor(typeMixedBinary, typeBinary, typeString, typeMixedString)...)
+	testCases = append(testCases, testCasesFor(typeMixedString, typeBinary, typeString, typeMixedBinary)...)
+
+	ctx := context.Background()
+
+	for _, tc := range testCases {
+		// Deep copy resources to ensure all tests are independent.
+		c := fake.NewSimpleClientset(
+			validEmptySecret.DeepCopy(),
+			validBinarySecret.DeepCopy(),
+			validStringSecret.DeepCopy(),
+			validMixedSecret.DeepCopy(),
+		)
+
+		provider, err := newWatchProvider(ctx, log.NewNopLogger(), c)
+		require.NoError(t, err)
+
+		t.Run(tc.description, func(t *testing.T) {
+			tc.test(ctx, c, provider)
+			require.Equal(t, true, provider.isClean())
+		})
+	}
+}

--- a/secrets/kubernetes/watch.go
+++ b/secrets/kubernetes/watch.go
@@ -1,0 +1,239 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/prometheus/prometheus/secrets"
+)
+
+type WatchSPConfig struct {
+	ClientConfig
+}
+
+// Name returns the name of the Config.
+func (*WatchSPConfig) Name() string { return "kubernetes_watch" }
+
+// NewDiscoverer returns a Discoverer for the Config.
+func (c *WatchSPConfig) NewProvider(ctx context.Context, opts secrets.ProviderOptions) (secrets.Provider[SecretConfig], error) {
+	client, err := c.ClientConfig.client()
+	if err != nil {
+		return nil, err
+	}
+	return newWatchProvider(ctx, opts.Logger, client)
+}
+
+type watcher struct {
+	mu       sync.Mutex
+	w        watch.Interface
+	refCount uint
+	s        *corev1.Secret
+}
+
+func newWatcher(ctx context.Context, logger log.Logger, client kubernetes.Interface, config *SecretConfig) (*watcher, error) {
+	val := &watcher{
+		refCount: 1,
+	}
+
+	var err error
+	val.w, err = client.CoreV1().Secrets(config.Namespace).Watch(ctx, metav1.ListOptions{
+		FieldSelector:       fields.OneTermEqualSelector(metav1.ObjectNameField, config.Name).String(),
+		AllowWatchBookmarks: false,
+	})
+	if err != nil {
+		return val, fmt.Errorf("unable to watch secret %s/%s: %w", config.Namespace, config.Name, err)
+	}
+
+	// We could wait for the first watch event, but it doesn't notify us if the resource doesn't exist.
+	val.s, err = client.CoreV1().Secrets(config.Namespace).Get(ctx, config.Name, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return val, fmt.Errorf("unable to fetch secret %s/%s: %w", config.Namespace, config.Name, err)
+	}
+	go func() {
+		for {
+		channelLoop:
+			for {
+				select {
+				case e, ok := <-val.w.ResultChan():
+					if !ok {
+						break channelLoop
+					}
+					val.update(logger, client, e, config)
+				case <-ctx.Done():
+					// Run within separate function so we can use defer.
+					func() {
+						val.mu.Lock()
+						defer val.mu.Unlock()
+						val.w.Stop()
+					}()
+					return
+				}
+			}
+
+			// Run within separate function so we can use defer.
+			finished := func() bool {
+				// Check in case the channel cancelled intentionally.
+				if val.refCount == 0 {
+					return true
+				}
+
+				// Pseudo-arbitrarily jitter the length of the most common scrape interval.
+				time.Sleep(1*time.Second + time.Duration(rand.Intn(30)))
+
+				// Lock the watcher so it doesn't cancel before we restart.
+				val.mu.Lock()
+				defer val.mu.Unlock()
+
+				// Check again in case the watcher cancelled while we were waiting for the mutex.
+				if val.refCount == 0 {
+					return true
+				}
+				val.w, err = client.CoreV1().Secrets(config.Namespace).Watch(ctx, metav1.ListOptions{
+					FieldSelector:       fields.OneTermEqualSelector(metav1.ObjectNameField, config.Name).String(),
+					AllowWatchBookmarks: false,
+				})
+				if err != nil {
+					logger.Log("msg", "unable to restart watch for secret", "err", err, "namespace", config.Namespace, "name", config.Name)
+				}
+				return false
+			}()
+			if finished {
+				return
+			}
+		}
+	}()
+
+	return val, nil
+}
+
+func (w *watcher) update(logger log.Logger, client kubernetes.Interface, e watch.Event, config *SecretConfig) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if e.Type == "" && e.Object == nil {
+		return
+	}
+	switch e.Type {
+	case watch.Modified, watch.Added:
+		secret := e.Object.(*corev1.Secret)
+		w.s = secret
+	case watch.Deleted:
+		w.s = nil
+	case watch.Bookmark:
+		// Disabled explicitly when creating the watch interface.
+	case watch.Error:
+		logger.Log("msg", "watch error event", "namespace", w.s.Namespace, "name", w.s.Name)
+	}
+}
+
+func (w *watcher) secret(config *SecretConfig) secrets.Secret {
+	fn := secrets.SecretFn(func(ctx context.Context) (string, error) {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		if w.s == nil {
+			return "", fmt.Errorf("secret %s/%s not found", config.Namespace, config.Name)
+		}
+		return getKey(w.s, config.Key)
+	})
+	return &fn
+}
+
+type watchProvider struct {
+	ctx                context.Context
+	client             kubernetes.Interface
+	secretKeyToWatcher map[string]*watcher
+	logger             log.Logger
+}
+
+func newWatchProvider(ctx context.Context, logger log.Logger, client kubernetes.Interface) (*watchProvider, error) {
+	return &watchProvider{
+		ctx:                ctx,
+		client:             client,
+		secretKeyToWatcher: map[string]*watcher{},
+		logger:             logger,
+	}, nil
+}
+
+func (p *watchProvider) Add(ctx context.Context, config *SecretConfig) (secrets.Secret, error) {
+	keyStr := config.objectKey().String()
+	val, ok := p.secretKeyToWatcher[keyStr]
+	if ok {
+		val.refCount += 1
+		return nil, nil
+	}
+
+	var err error
+	val, err = newWatcher(ctx, p.logger, p.client, config)
+	if err != nil {
+		return nil, err
+	}
+
+	p.secretKeyToWatcher[keyStr] = val
+	return val.secret(config), nil
+}
+
+func (p *watchProvider) Update(ctx context.Context, configBefore, configAfter *SecretConfig) (secrets.Secret, error) {
+	secretBefore := configBefore.objectKey()
+	secretAfter := configAfter.objectKey()
+	if secretBefore == secretAfter {
+		// If we're using the same secret with a different key, just remap your current watch.
+		val := p.secretKeyToWatcher[secretAfter.String()]
+		if val == nil {
+			return nil, fmt.Errorf("secret %s/%s not found", configAfter.Namespace, configAfter.Name)
+		}
+		return val.secret(configAfter), nil
+	}
+	if err := p.Remove(ctx, configBefore); err != nil {
+		return nil, err
+	}
+	return p.Add(ctx, configAfter)
+}
+
+func (p *watchProvider) Remove(ctx context.Context, config *SecretConfig) error {
+	key := config.objectKey().String()
+	val := p.secretKeyToWatcher[key]
+	if val == nil {
+		return nil
+	}
+
+	delete(p.secretKeyToWatcher, key)
+
+	// Lock the watcher so it doesn't restart, and cancel intentionally.
+	val.mu.Lock()
+	defer val.mu.Unlock()
+
+	val.refCount -= 1
+	if val.refCount > 0 {
+		return nil
+	}
+	val.w.Stop()
+	return nil
+}
+
+func (p *watchProvider) isClean() bool {
+	return len(p.secretKeyToWatcher) == 0
+}

--- a/secrets/manager.go
+++ b/secrets/manager.go
@@ -1,0 +1,218 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secrets
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/yaml.v2"
+)
+
+var (
+	failedSecretConfigs = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "prometheus_sp_failed_secret_configs",
+			Help: "Current number of secret configurations that failed to load.",
+		},
+	)
+	secretsTotal = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "prometheus_sp_secrets_total",
+			Help: "Current number of secrets.",
+		},
+	)
+)
+
+func yamlSerialize(obj any) ([]byte, error) {
+	if obj == nil {
+		return []byte{}, nil
+	}
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	if err := encoder.Encode(obj); err != nil {
+		return nil, err
+	}
+	if err := encoder.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func yamlEqual(x, y any) (bool, error) {
+	yamlX, err := yamlSerialize(x)
+	if err != nil {
+		return false, err
+	}
+	yamlY, err := yamlSerialize(y)
+	if err != nil {
+		return false, err
+	}
+	return bytes.Equal(yamlX, yamlY), nil
+}
+
+type SecretConfig[T any] struct {
+	Name   string `yaml:"name"`
+	Config T      `yaml:"config"`
+}
+
+type SecretEntry[T any] struct {
+	config T
+	secret Secret
+}
+
+type ProviderManager[T any] struct {
+	ctx      context.Context
+	cancelFn func()
+	provider Provider[T]
+	config   Config[T]
+	secrets  map[string]*SecretEntry[T]
+}
+
+func NewProviderManager[T any](ctx context.Context, reg prometheus.Registerer) ProviderManager[T] {
+	if reg != nil {
+		reg.MustRegister(failedSecretConfigs)
+		reg.MustRegister(secretsTotal)
+	}
+	return ProviderManager[T]{
+		ctx:      ctx,
+		cancelFn: func() {},
+		secrets:  make(map[string]*SecretEntry[T]),
+	}
+}
+
+func (m *ProviderManager[T]) ApplyConfig(ctx context.Context, providerConfig Config[T], configs []SecretConfig[T]) error {
+	// If no secrets are provided, cancel any existing secret provider.
+	if len(configs) == 0 {
+		m.cancelFn()
+		m.provider = nil
+		m.cancelFn = func() {}
+		m.secrets = map[string]*SecretEntry[T]{}
+		m.config = nil
+		return nil
+	}
+
+	eq, err := yamlEqual(m.config, providerConfig)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		m.config = providerConfig
+	}()
+
+	if !eq || m.provider == nil {
+		ctx, cancel := context.WithCancel(m.ctx)
+		provider, err := providerConfig.NewProvider(ctx, ProviderOptions{})
+		if err != nil {
+			cancel()
+			return err
+		}
+
+		m.cancelFn()
+		m.provider = provider
+		m.cancelFn = cancel
+		m.secrets = map[string]*SecretEntry[T]{}
+	}
+	return m.updateSecrets(ctx, configs)
+}
+
+func (m *ProviderManager[T]) updateSecrets(ctx context.Context, configs []SecretConfig[T]) error {
+	var errs []error
+	secretNamesEnabled := make(map[string]bool)
+	for _, secret := range configs {
+		if enabled, ok := secretNamesEnabled[secret.Name]; ok {
+			if !enabled {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("duplicate secret key %q", secret.Name))
+			secretNamesEnabled[secret.Name] = false
+		} else {
+			secretNamesEnabled[secret.Name] = true
+		}
+	}
+
+	newSecrets := map[string]*SecretEntry[T]{}
+	for i := range configs {
+		secret := &configs[i]
+		if enabled := secretNamesEnabled[secret.Name]; !enabled {
+			continue
+		}
+		if secretConfig, ok := m.secrets[secret.Name]; ok {
+			eq, err := yamlEqual(&secretConfig.config, &secret.Config)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			delete(m.secrets, secret.Name)
+			if eq {
+				newSecrets[secret.Name] = secretConfig
+				continue
+			}
+			s, err := m.provider.Update(ctx, &secretConfig.config, &secret.Config)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			secretConfig.secret = s
+			newSecrets[secret.Name] = secretConfig
+			continue
+		}
+		s, err := m.provider.Add(ctx, &secret.Config)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		newSecrets[secret.Name] = &SecretEntry[T]{
+			config: secret.Config,
+			secret: s,
+		}
+	}
+	for _, unusedSecret := range m.secrets {
+		if err := m.provider.Remove(ctx, &unusedSecret.config); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	m.secrets = newSecrets
+
+	total := len(secretNamesEnabled)
+	success := len(m.secrets)
+	failedSecretConfigs.Set(float64(total - success))
+	secretsTotal.Set(float64(total))
+	return errors.Join(errs...)
+}
+
+func (m *ProviderManager[T]) Fetch(ctx context.Context, name string) (string, error) {
+	secret, ok := m.secrets[name]
+	if !ok {
+		return "", fmt.Errorf("secret %q not found", name)
+	}
+	return secret.secret.Fetch(ctx)
+}
+
+func (m *ProviderManager[T]) Close(reg prometheus.Registerer) {
+	m.cancelFn()
+	if reg != nil {
+		reg.Unregister(failedSecretConfigs)
+		reg.Unregister(secretsTotal)
+	}
+}
+
+func (m *ProviderManager[T]) secretCount() int {
+	return len(m.secrets)
+}

--- a/secrets/manager_test.go
+++ b/secrets/manager_test.go
@@ -1,0 +1,559 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secrets
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+type testSecret struct {
+	Foo string `yaml:"foo"`
+}
+
+func makeTestSecretData(config, value string, id int) string {
+	return fmt.Sprintf("%s-%d-foo: %s", config, id, value)
+}
+
+type testConfig struct {
+	Prefix string `yaml:"prefix"`
+	// Don't serialize this. Use this ID to determine if the config was changed.
+	configID int
+}
+
+func (p *testConfig) Name() string {
+	return "prefix"
+}
+
+func (p *testConfig) NewProvider(ctx context.Context, opts ProviderOptions) (Provider[testSecret], error) {
+	provider := &testProvider{
+		config: p.Prefix,
+		id:     p.configID,
+	}
+	p.configID += 1
+	return provider, nil
+}
+
+const invalidTestSecretConfigValue = "blue"
+
+var errInvalidTestSecretConfig = errors.New("invalid secret config")
+
+type testProvider struct {
+	config string
+	id     int
+}
+
+func (p *testProvider) Add(ctx context.Context, config *testSecret) (Secret, error) {
+	if config.Foo == "" {
+		return nil, errInvalidTestSecretConfig
+	}
+	secret := SecretFn(func(ctx context.Context) (string, error) {
+		if config.Foo == invalidTestSecretConfigValue {
+			return "", errInvalidTestSecretConfig
+		}
+		return makeTestSecretData(p.config, config.Foo, p.id), nil
+	})
+	return &secret, nil
+}
+
+func (p *testProvider) Update(ctx context.Context, configBefore, configAfter *testSecret) (Secret, error) {
+	return p.Add(ctx, configAfter)
+}
+
+func (p *testProvider) Remove(ctx context.Context, config *testSecret) error {
+	return nil
+}
+
+type dataOrError struct {
+	data string
+	err  error
+}
+
+func assertApplyConfig(ctx context.Context, t testing.TB, description string, manager *ProviderManager[testSecret], providerConfig *testConfig, config []SecretConfig[testSecret], secrets map[string]dataOrError, expectedErr error) {
+	configCopy := config
+	if err := manager.ApplyConfig(ctx, providerConfig, configCopy); err != nil {
+		if expectedErr == nil || (!errors.Is(err, expectedErr) && err.Error() != expectedErr.Error()) {
+			t.Fatalf("expected %s error %q but got: %s", description, expectedErr, err)
+		}
+	} else if expectedErr != nil {
+		t.Fatalf("expected %s error %q but got none", description, expectedErr)
+	}
+	for name, value := range secrets {
+		data, err := manager.Fetch(context.Background(), name)
+		if err != nil {
+			if value.err != nil {
+				if errors.Is(err, value.err) {
+					continue
+				}
+				t.Fatalf("expected error %q for %s secret %q but got: %s", value.err, description, name, err)
+			}
+			t.Fatalf("unexpected error for %s secret %q: %s", description, name, err)
+		}
+		if data != value.data {
+			t.Fatalf("expected data %q for %s secret %q but got: %s", value.data, description, name, data)
+		}
+	}
+	if manager.secretCount() != len(secrets) {
+		t.Errorf("expected %s %d secrets but found %d", description, len(secrets), manager.secretCount())
+	}
+}
+
+func testValues(config *testConfig) ([]SecretConfig[testSecret], map[string]dataOrError) {
+	return []SecretConfig[testSecret]{
+			{
+				Name: "abc",
+				Config: testSecret{
+					Foo: "green",
+				},
+			},
+			{
+				Name: "xyz",
+				Config: testSecret{
+					Foo: "orange",
+				},
+			},
+		}, map[string]dataOrError{
+			"abc": {
+				data: makeTestSecretData(config.Prefix, "green", config.configID),
+			},
+			"xyz": {
+				data: makeTestSecretData(config.Prefix, "orange", config.configID),
+			},
+		}
+}
+
+func updateSecret(configs []SecretConfig[testSecret], secrets map[string]dataOrError, index int, value string, result dataOrError) {
+	configs[index].Config.Foo = value
+	if value == "" {
+		delete(secrets, configs[index].Name)
+		return
+	}
+	secrets[configs[index].Name] = result
+}
+
+func updateSecretInvalid(configs []SecretConfig[testSecret], secrets map[string]dataOrError, index int) {
+	updateSecret(configs, secrets, index, invalidTestSecretConfigValue, dataOrError{
+		err: errInvalidTestSecretConfig,
+	})
+}
+
+func updateSecretError(configs []SecretConfig[testSecret], secrets map[string]dataOrError, index int) {
+	updateSecret(configs, secrets, index, "", dataOrError{})
+}
+
+func TestProviderConfig(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	testCases := []struct {
+		description string
+		testFn      func(t testing.TB, manager *ProviderManager[testSecret])
+	}{
+		{
+			description: "no change invalid",
+			testFn: func(t testing.TB, manager *ProviderManager[testSecret]) {
+				providerConfigInitial := &testConfig{
+					Prefix:   "i",
+					configID: 1,
+				}
+				config, secrets := testValues(providerConfigInitial)
+				updateSecretError(config, secrets, 0)
+				assertApplyConfig(ctx, t, "initial", manager, providerConfigInitial, config, secrets, errInvalidTestSecretConfig)
+				if providerConfigInitial.configID != 2 {
+					t.Fatalf("Initial provider not called")
+				}
+
+				providerConfigFinal := &testConfig{
+					Prefix:   "i",
+					configID: 1,
+				}
+				assertApplyConfig(ctx, t, "final", manager, providerConfigFinal, config, secrets, errInvalidTestSecretConfig)
+				if e, a := 1, providerConfigFinal.configID; e != a {
+					t.Fatalf("Final provider config has wrong value, expected %d actual %d", e, a)
+				}
+			},
+		},
+		{
+			description: "no change valid",
+			testFn: func(t testing.TB, manager *ProviderManager[testSecret]) {
+				providerConfigInitial := &testConfig{
+					Prefix:   "i",
+					configID: 1,
+				}
+				config, secrets := testValues(providerConfigInitial)
+				assertApplyConfig(ctx, t, "initial", manager, providerConfigInitial, config, secrets, nil)
+				if providerConfigInitial.configID != 2 {
+					t.Fatalf("Initial provider not called")
+				}
+
+				providerConfigFinal := &testConfig{
+					Prefix:   "i",
+					configID: 1,
+				}
+				assertApplyConfig(ctx, t, "final", manager, providerConfigFinal, config, secrets, nil)
+				if e, a := 1, providerConfigFinal.configID; e != a {
+					t.Fatalf("Final provider config has wrong value, expected %d actual %d", e, a)
+				}
+			},
+		},
+		{
+			description: "no config change invalid",
+			testFn: func(t testing.TB, manager *ProviderManager[testSecret]) {
+				providerConfigInitial := &testConfig{
+					Prefix:   "i",
+					configID: 1,
+				}
+				config, secrets := testValues(providerConfigInitial)
+				updateSecretError(config, secrets, 0)
+				assertApplyConfig(ctx, t, "initial", manager, providerConfigInitial, config, secrets, errInvalidTestSecretConfig)
+				if providerConfigInitial.configID != 2 {
+					t.Fatalf("Initial provider not called")
+				}
+
+				providerConfigFinal := &testConfig{
+					Prefix:   "i",
+					configID: 10,
+				}
+				assertApplyConfig(ctx, t, "final", manager, providerConfigFinal, config, secrets, errInvalidTestSecretConfig)
+				if e, a := 10, providerConfigFinal.configID; e != a {
+					t.Fatalf("Final provider config has wrong value, expected %d actual %d", e, a)
+				}
+			},
+		},
+		{
+			description: "no config change valid",
+			testFn: func(t testing.TB, manager *ProviderManager[testSecret]) {
+				providerConfigInitial := &testConfig{
+					Prefix:   "i",
+					configID: 1,
+				}
+				config, secrets := testValues(providerConfigInitial)
+				assertApplyConfig(ctx, t, "initial", manager, providerConfigInitial, config, secrets, nil)
+				if providerConfigInitial.configID != 2 {
+					t.Fatalf("Initial provider not called")
+				}
+
+				providerConfigFinal := &testConfig{
+					Prefix:   "i",
+					configID: 10,
+				}
+				assertApplyConfig(ctx, t, "final", manager, providerConfigFinal, config, secrets, nil)
+				if e, a := 10, providerConfigFinal.configID; e != a {
+					t.Fatalf("Final provider config has wrong value, expected %d actual %d", e, a)
+				}
+			},
+		},
+		{
+			description: "config change invalid",
+			testFn: func(t testing.TB, manager *ProviderManager[testSecret]) {
+				providerConfigInitial := &testConfig{
+					Prefix:   "i",
+					configID: 1,
+				}
+				config, secrets := testValues(providerConfigInitial)
+				updateSecretError(config, secrets, 0)
+				assertApplyConfig(ctx, t, "initial", manager, providerConfigInitial, config, secrets, errInvalidTestSecretConfig)
+				if providerConfigInitial.configID != 2 {
+					t.Fatalf("Initial provider not called")
+				}
+
+				providerConfigFinal := &testConfig{
+					Prefix:   "j",
+					configID: 10,
+				}
+				config, secrets = testValues(providerConfigFinal)
+				updateSecretError(config, secrets, 0)
+				assertApplyConfig(ctx, t, "final", manager, providerConfigFinal, config, secrets, errInvalidTestSecretConfig)
+				if e, a := 11, providerConfigFinal.configID; e != a {
+					t.Fatalf("Final provider config has wrong value, expected %d actual %d", e, a)
+				}
+			},
+		},
+		{
+			description: "config change valid",
+			testFn: func(t testing.TB, manager *ProviderManager[testSecret]) {
+				providerConfigInitial := &testConfig{
+					Prefix:   "i",
+					configID: 1,
+				}
+				config, secrets := testValues(providerConfigInitial)
+				assertApplyConfig(ctx, t, "initial", manager, providerConfigInitial, config, secrets, nil)
+				if providerConfigInitial.configID != 2 {
+					t.Fatalf("Initial provider not called")
+				}
+
+				providerConfigFinal := &testConfig{
+					Prefix:   "j",
+					configID: 10,
+				}
+				config, secrets = testValues(providerConfigFinal)
+				assertApplyConfig(ctx, t, "final", manager, providerConfigFinal, config, secrets, nil)
+				if e, a := 11, providerConfigFinal.configID; e != a {
+					t.Fatalf("Final provider config has wrong value, expected %d actual %d", e, a)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			manager := NewProviderManager[testSecret](ctx, nil)
+			defer manager.Close(nil)
+			tc.testFn(t, &manager)
+		})
+	}
+}
+
+func TestSecretConfig(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	getProviderConfig := func() *testConfig {
+		return &testConfig{
+			Prefix:   "i",
+			configID: 1,
+		}
+	}
+	assertConfigState := func(ctx context.Context, t testing.TB, description string, manager *ProviderManager[testSecret], config []SecretConfig[testSecret], secrets map[string]dataOrError) {
+		assertApplyConfig(ctx, t, description, manager, getProviderConfig(), config, secrets, nil)
+	}
+	commonTestValues := func() ([]SecretConfig[testSecret], map[string]dataOrError) {
+		return testValues(getProviderConfig())
+	}
+
+	testCases := []struct {
+		description string
+		testFn      func(t testing.TB, manager *ProviderManager[testSecret])
+	}{
+		{
+			description: "no change none",
+			testFn: func(t testing.TB, manager *ProviderManager[testSecret]) {
+				configs, secrets := []SecretConfig[testSecret]{}, map[string]dataOrError{}
+				assertConfigState(ctx, t, "initial", manager, configs, secrets)
+				assertConfigState(ctx, t, "final", manager, configs, secrets)
+			},
+		},
+		{
+			description: "no change valid",
+			testFn: func(t testing.TB, manager *ProviderManager[testSecret]) {
+				configs, secrets := commonTestValues()
+				assertConfigState(ctx, t, "initial", manager, configs, secrets)
+				assertConfigState(ctx, t, "final", manager, configs, secrets)
+			},
+		},
+		{
+			description: "no change invalid",
+			testFn: func(t testing.TB, manager *ProviderManager[testSecret]) {
+				configs, secrets := commonTestValues()
+				updateSecretInvalid(configs, secrets, 0)
+				assertConfigState(ctx, t, "initial", manager, configs, secrets)
+				assertConfigState(ctx, t, "final", manager, configs, secrets)
+			},
+		},
+		{
+			description: "add invalid to none",
+			testFn: func(t testing.TB, manager *ProviderManager[testSecret]) {
+				configs, secrets := []SecretConfig[testSecret]{}, map[string]dataOrError{}
+				assertConfigState(ctx, t, "initial", manager, configs, secrets)
+
+				configs = append(configs, SecretConfig[testSecret]{
+					Name: "123",
+					Config: testSecret{
+						Foo: invalidTestSecretConfigValue,
+					},
+				})
+				secrets["123"] = dataOrError{
+					err: errInvalidTestSecretConfig,
+				}
+				assertConfigState(ctx, t, "final", manager, configs, secrets)
+			},
+		},
+		{
+			description: "add valid to none",
+			testFn: func(t testing.TB, manager *ProviderManager[testSecret]) {
+				configs, secrets := []SecretConfig[testSecret]{}, map[string]dataOrError{}
+				assertConfigState(ctx, t, "initial", manager, configs, secrets)
+
+				configs = append(configs, SecretConfig[testSecret]{
+					Name: "123",
+					Config: testSecret{
+						Foo: "red",
+					},
+				})
+				secrets["123"] = dataOrError{
+					data: makeTestSecretData("i", "red", 1),
+				}
+				assertConfigState(ctx, t, "final", manager, configs, secrets)
+			},
+		},
+		{
+			description: "add invalid to some",
+			testFn: func(t testing.TB, manager *ProviderManager[testSecret]) {
+				configs, secrets := commonTestValues()
+				assertConfigState(ctx, t, "initial", manager, configs, secrets)
+
+				configs = append(configs, SecretConfig[testSecret]{
+					Name: "123",
+					Config: testSecret{
+						Foo: invalidTestSecretConfigValue,
+					},
+				})
+				secrets["123"] = dataOrError{
+					err: errInvalidTestSecretConfig,
+				}
+				assertConfigState(ctx, t, "final", manager, configs, secrets)
+			},
+		},
+		{
+			description: "add duplicate to some",
+			testFn: func(t testing.TB, manager *ProviderManager[testSecret]) {
+				configs, secrets := commonTestValues()
+				assertConfigState(ctx, t, "initial", manager, configs, secrets)
+
+				delete(secrets, configs[0].Name)
+				delete(secrets, configs[1].Name)
+				configs[1].Name = configs[0].Name
+				assertApplyConfig(ctx, t, "final", manager, getProviderConfig(), configs, secrets, fmt.Errorf("duplicate secret key %q", configs[0].Name))
+			},
+		},
+		{
+			description: "add valid to some",
+			testFn: func(t testing.TB, manager *ProviderManager[testSecret]) {
+				configs, secrets := commonTestValues()
+				assertConfigState(ctx, t, "initial", manager, configs, secrets)
+
+				configs = append(configs, SecretConfig[testSecret]{
+					Name: "123",
+					Config: testSecret{
+						Foo: "red",
+					},
+				})
+				secrets["123"] = dataOrError{
+					data: makeTestSecretData("i", "red", 1),
+				}
+				assertConfigState(ctx, t, "final", manager, configs, secrets)
+			},
+		},
+		{
+			description: "update invalid",
+			testFn: func(t testing.TB, manager *ProviderManager[testSecret]) {
+				configs, secrets := commonTestValues()
+				updateSecretInvalid(configs, secrets, 0)
+				assertConfigState(ctx, t, "initial", manager, configs, secrets)
+
+				configs[0].Config.Foo = "red"
+				secrets[configs[0].Name] = dataOrError{
+					data: makeTestSecretData("i", "red", 1),
+				}
+				assertConfigState(ctx, t, "final", manager, configs, secrets)
+			},
+		},
+		{
+			description: "update valid",
+			testFn: func(t testing.TB, manager *ProviderManager[testSecret]) {
+				configs, secrets := commonTestValues()
+				assertConfigState(ctx, t, "initial", manager, configs, secrets)
+
+				configs[0].Config.Foo = "red"
+				secrets[configs[0].Name] = dataOrError{
+					data: makeTestSecretData("i", "red", 1),
+				}
+				assertConfigState(ctx, t, "final", manager, configs, secrets)
+			},
+		},
+		{
+			description: "replace invalid",
+			testFn: func(t testing.TB, manager *ProviderManager[testSecret]) {
+				configs, secrets := commonTestValues()
+				updateSecretInvalid(configs, secrets, 0)
+				assertConfigState(ctx, t, "initial", manager, configs, secrets)
+
+				delete(secrets, configs[0].Name)
+				configs[0] = SecretConfig[testSecret]{
+					Name: "123",
+					Config: testSecret{
+						Foo: "red",
+					},
+				}
+				secrets["123"] = dataOrError{
+					data: makeTestSecretData("i", "red", 1),
+				}
+				assertConfigState(ctx, t, "final", manager, configs, secrets)
+			},
+		},
+		{
+			description: "replace valid",
+			testFn: func(t testing.TB, manager *ProviderManager[testSecret]) {
+				configs, secrets := commonTestValues()
+				assertConfigState(ctx, t, "initial", manager, configs, secrets)
+
+				delete(secrets, configs[0].Name)
+				configs[0] = SecretConfig[testSecret]{
+					Name: "123",
+					Config: testSecret{
+						Foo: "red",
+					},
+				}
+				secrets["123"] = dataOrError{
+					data: makeTestSecretData("i", "red", 1),
+				}
+				assertConfigState(ctx, t, "final", manager, configs, secrets)
+			},
+		},
+		{
+			description: "remove invalid",
+			testFn: func(t testing.TB, manager *ProviderManager[testSecret]) {
+				configs, secrets := commonTestValues()
+				updateSecretInvalid(configs, secrets, 0)
+				assertConfigState(ctx, t, "initial", manager, configs, secrets)
+
+				delete(secrets, configs[0].Name)
+				configs = configs[1:]
+				assertConfigState(ctx, t, "final", manager, configs, secrets)
+			},
+		},
+		{
+			description: "remove valid",
+			testFn: func(t testing.TB, manager *ProviderManager[testSecret]) {
+				configs, secrets := commonTestValues()
+				assertConfigState(ctx, t, "initial", manager, configs, secrets)
+
+				delete(secrets, configs[0].Name)
+				configs = configs[1:]
+				assertConfigState(ctx, t, "final", manager, configs, secrets)
+			},
+		},
+		{
+			description: "clear all",
+			testFn: func(t testing.TB, manager *ProviderManager[testSecret]) {
+				configs, secrets := commonTestValues()
+				updateSecretInvalid(configs, secrets, 0)
+				assertConfigState(ctx, t, "initial", manager, configs, secrets)
+
+				configs, secrets = []SecretConfig[testSecret]{}, map[string]dataOrError{}
+				assertConfigState(ctx, t, "final", manager, configs, secrets)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			manager := NewProviderManager[testSecret](ctx, nil)
+			defer manager.Close(nil)
+			tc.testFn(t, &manager)
+		})
+	}
+}

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -1,0 +1,59 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secrets
+
+import (
+	"context"
+
+	"github.com/go-kit/log"
+)
+
+// Secret represents a sensitive value.
+type Secret interface {
+	// Fetch fetches the secret content.
+	Fetch(ctx context.Context) (string, error)
+}
+
+// SecretFn wraps a function to make it a Secret.
+type SecretFn func(ctx context.Context) (string, error)
+
+func (fn *SecretFn) Fetch(ctx context.Context) (string, error) {
+	return (*fn)(ctx)
+}
+
+// Provider is a secret provider.
+type Provider[T any] interface {
+	// Add returns the secret fetcher for the given configuration.
+	Add(ctx context.Context, config *T) (Secret, error)
+
+	// Update returns the secret fetcher for the new configuration.
+	Update(ctx context.Context, configBefore, configAfter *T) (Secret, error)
+
+	// Remove ensures that the secret fetcher for the configuration is invalid.
+	Remove(ctx context.Context, config *T) error
+}
+
+// ProviderOptions provides options for a Provider.
+type ProviderOptions struct {
+	Logger log.Logger
+}
+
+// Config provides the configuration and constructor for a Provider.
+type Config[T any] interface {
+	// Name returns the name of the secret provider.
+	Name() string
+
+	// NewProvider creates a new Provider with the options.
+	NewProvider(ctx context.Context, opts ProviderOptions) (Provider[T], error)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -572,8 +572,8 @@ github.com/prometheus/client_golang/prometheus/testutil/promlint/validations
 # github.com/prometheus/client_model v0.5.0
 ## explicit; go 1.19
 github.com/prometheus/client_model/go
-# github.com/prometheus/common v0.45.0 => github.com/TheSpiritXIII/prometheus-common v0.43.0-gmp.0
-## explicit; go 1.18
+# github.com/prometheus/common v0.45.0 => github.com/TheSpiritXIII/prometheus-common v0.43.0-gmp.1
+## explicit; go 1.20
 github.com/prometheus/common/config
 github.com/prometheus/common/expfmt
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
@@ -1339,6 +1339,6 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/prometheus/common => github.com/TheSpiritXIII/prometheus-common v0.43.0-gmp.0
+# github.com/prometheus/common => github.com/TheSpiritXIII/prometheus-common v0.43.0-gmp.1
 # k8s.io/klog => github.com/simonpasquier/klog-gokit v0.3.0
 # k8s.io/klog/v2 => github.com/simonpasquier/klog-gokit/v3 v3.4.0


### PR DESCRIPTION
This PR adds support for fetching native Kubernetes secrets to Prometheus for authorization.

The plan is that this PR would eventually be superseded by upstream efforts (see https://github.com/prometheus/alertmanager/issues/3108#issuecomment-1781912503).

This is a slimmed down version of what could eventually become an upstream change. While some of the code uses a generic `SecretProvider` interface, the new configs are harded-coded Kubernetes `secrets` (which maps a secret reference name to a Kubernetes secret) and a new `kubernetes_sp_config` (which configures the connection to the Kubernetes API server). Then, that secret name is referenced in the authorization config, e.g. for BasicAuth it would be `password_ref`. These would eventually be replaced with the upstream version when they get released.

One way this implementation differs from service discovery is that configuration changes are incremental: when a secret is added or removed, the Kubernetes secret provider simply adds or removes a Kubernetes WATCH API call, while existing watches are kept in-tact.