### PR TITLE
feat: add a native Kubernetes secret provider (v2.45)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/prometheus-engine/pkg/secrets"
 	"github.com/alecthomas/units"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -225,6 +226,10 @@ type Config struct {
 	ScrapeConfigs     []*ScrapeConfig `yaml:"scrape_configs,omitempty"`
 	StorageConfig     StorageConfig   `yaml:"storage,omitempty"`
 	TracingConfig     TracingConfig   `yaml:"tracing,omitempty"`
+
+	// Secret management:
+	secrets.ClientConfig `yaml:"kubernetes_sp_config,omitempty"`
+	SecretConfigs        []secrets.SecretConfig `yaml:"kubernetes_secrets,omitempty"`
 
 	RemoteWriteConfigs []*RemoteWriteConfig `yaml:"remote_write,omitempty"`
 	RemoteReadConfigs  []*RemoteReadConfig  `yaml:"remote_read,omitempty"`

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.2.1
 	github.com/Azure/go-autorest/autorest v0.11.29
 	github.com/Azure/go-autorest/autorest/adal v0.9.23
-	github.com/GoogleCloudPlatform/prometheus-engine v0.11.0-rc.0
+	github.com/GoogleCloudPlatform/prometheus-engine v0.11.0-rc.2
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
 	github.com/aws/aws-sdk-go v1.44.276
@@ -19,7 +19,7 @@ require (
 	github.com/edsrzf/mmap-go v1.1.0
 	github.com/envoyproxy/go-control-plane v0.11.1
 	github.com/envoyproxy/protoc-gen-validate v1.0.2
-	github.com/fsnotify/fsnotify v1.6.0
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-kit/log v0.2.1
 	github.com/go-logfmt/logfmt v0.6.0
 	github.com/go-openapi/strfmt v0.21.7
@@ -46,7 +46,7 @@ require (
 	github.com/prometheus/alertmanager v0.25.1
 	github.com/prometheus/client_golang v1.18.0
 	github.com/prometheus/client_model v0.5.0
-	github.com/prometheus/common v0.45.0
+	github.com/prometheus/common v0.47.0
 	github.com/prometheus/common/assets v0.2.0
 	github.com/prometheus/common/sigv4 v0.1.0
 	github.com/prometheus/exporter-toolkit v0.10.0
@@ -206,7 +206,11 @@ replace (
 	// - https://github.com/prometheus/common/pull/546
 	// - https://github.com/prometheus/common/pull/547
 	// prometheus/common v0.47 has these fixes but is incompatiable with this Prometheus version.
-	github.com/prometheus/common => github.com/TheSpiritXIII/prometheus-common v0.45.0-gmp.0
+	//
+	// We also need these changes for secret management:
+	// - https://github.com/prometheus/common/pull/538
+	// - https://github.com/prometheus/common/pull/572
+	github.com/prometheus/common => github.com/TheSpiritXIII/prometheus-common v0.45.0-gmp.1
 	k8s.io/klog => github.com/simonpasquier/klog-gokit v0.3.0
 	k8s.io/klog/v2 => github.com/simonpasquier/klog-gokit/v3 v3.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -636,8 +636,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v0.8.1/go.mod h1:4qFo
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
-github.com/GoogleCloudPlatform/prometheus-engine v0.11.0-rc.0 h1:tQpmhsWQPdxpv+81bHYU8VD/qw/EWvQocodp4q2XHRU=
-github.com/GoogleCloudPlatform/prometheus-engine v0.11.0-rc.0/go.mod h1:He26GbGY8kmjWJ9LPsMc4sk8OQrO/bOZp789Z1wBfwI=
+github.com/GoogleCloudPlatform/prometheus-engine v0.11.0-rc.2 h1:3CRePAdRmUkTGYdz1ITUUqgEqhurKfQ6g7XEzNIvHhM=
+github.com/GoogleCloudPlatform/prometheus-engine v0.11.0-rc.2/go.mod h1:dlUPioZeE5HVPjTKm6kiQZ1/ydV3WGLCfqmWKTgGZKU=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Microsoft/go-winio v0.6.0 h1:slsWYD/zyx7lCXoZVlvQrj0hPTM1HI4+v1sIda2yDvg=
@@ -647,8 +647,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
-github.com/TheSpiritXIII/prometheus-common v0.45.0-gmp.0 h1:Jl3EyQFtpyV0oVtx3fq2oLzdllUDC/Ah5EztpBjDHXQ=
-github.com/TheSpiritXIII/prometheus-common v0.45.0-gmp.0/go.mod h1:YJmSTw9BoKxJplESWWxlbyttQR4uaEcGyv9MZjVOJsY=
+github.com/TheSpiritXIII/prometheus-common v0.45.0-gmp.1 h1:j41pxlvtux7asbplNO7JptQecUnQ74nCqH1zNsVkmAQ=
+github.com/TheSpiritXIII/prometheus-common v0.45.0-gmp.1/go.mod h1:YJmSTw9BoKxJplESWWxlbyttQR4uaEcGyv9MZjVOJsY=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm/4RlzPXRlREEwqTHAN3T56Bv2ITsFT3gY=
@@ -799,8 +799,8 @@ github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzP
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
-github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
+github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=
@@ -1819,7 +1819,6 @@ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220829200755-d48e67d00261/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/vendor/github.com/GoogleCloudPlatform/prometheus-engine/pkg/export/export.go
+++ b/vendor/github.com/GoogleCloudPlatform/prometheus-engine/pkg/export/export.go
@@ -530,7 +530,7 @@ const (
 	ClientName = "prometheus-engine-export"
 	// mainModuleVersion is the version of the main module. Align with git tag.
 	// TODO(TheSpiritXIII): Remove with https://github.com/golang/go/issues/50603
-	mainModuleVersion = "v0.11.0-rc.0"
+	mainModuleVersion = "v0.11.0-rc.2" // x-release-please-version
 	// mainModuleName is the name of the main module. Align with go.mod.
 	mainModuleName = "github.com/GoogleCloudPlatform/prometheus-engine"
 )
@@ -569,11 +569,6 @@ func Version() (string, error) {
 			version = strings.TrimSpace(stdout.String())
 		}
 
-		if version != mainModuleVersion {
-			return "", fmt.Errorf("export version %q does not match tag %q", mainModuleVersion, version)
-		}
-
-		// To prevent breaking in unit tests.
 		return version, nil
 	}
 

--- a/vendor/github.com/GoogleCloudPlatform/prometheus-engine/pkg/secrets/config.go
+++ b/vendor/github.com/GoogleCloudPlatform/prometheus-engine/pkg/secrets/config.go
@@ -1,0 +1,40 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secrets
+
+import (
+	"context"
+
+	"github.com/go-kit/log"
+)
+
+// Secret represents a sensitive value.
+type Secret interface {
+	// Fetch fetches the secret content.
+	Fetch(ctx context.Context) (string, error)
+}
+
+// SecretFn wraps a function to make it a Secret.
+type SecretFn func(ctx context.Context) (string, error)
+
+// Fetch implements Secret.Fetch.
+func (fn *SecretFn) Fetch(ctx context.Context) (string, error) {
+	return (*fn)(ctx)
+}
+
+// ProviderOptions provides options for a Provider.
+type ProviderOptions struct {
+	Logger log.Logger
+}

--- a/vendor/github.com/GoogleCloudPlatform/prometheus-engine/pkg/secrets/kubernetes.go
+++ b/vendor/github.com/GoogleCloudPlatform/prometheus-engine/pkg/secrets/kubernetes.go
@@ -1,0 +1,83 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secrets
+
+import (
+	"fmt"
+
+	"github.com/prometheus/common/config"
+	"github.com/prometheus/common/version"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// HTTP header.
+var userAgent = fmt.Sprintf("Prometheus/%s", version.Version)
+
+// KubernetesSecretConfig is the configuration pointing to a specific Kubernetes Secret.
+type KubernetesSecretConfig struct {
+	Namespace string `yaml:"namespace"`
+	Name      string `yaml:"name"`
+	Key       string `yaml:"key"`
+}
+
+func (c *KubernetesSecretConfig) objectKey() types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: c.Namespace,
+		Name:      c.Name,
+	}
+}
+
+func getValue(s *corev1.Secret, key string) (string, error) {
+	if value, ok := s.Data[key]; ok {
+		return string(value), nil
+	}
+	if value, ok := s.StringData[key]; ok {
+		return value, nil
+	}
+	return "", fmt.Errorf("secret %s/%s does not contain key: %s", s.Namespace, s.Name, key)
+}
+
+// ClientConfig configures access to the Kubernetes API server.
+type ClientConfig struct {
+	APIServer  config.URL `yaml:"api_server,omitempty"`
+	KubeConfig string     `yaml:"kubeconfig_file,omitempty"`
+}
+
+func (c *ClientConfig) client() (kubernetes.Interface, error) {
+	var restClient *rest.Config
+	switch {
+	case c.KubeConfig != "":
+		var err error
+		restClient, err = clientcmd.BuildConfigFromFlags("", c.KubeConfig)
+		if err != nil {
+			return nil, err
+		}
+	case c.APIServer.URL == nil:
+		var err error
+		restClient, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	restClient.UserAgent = userAgent
+	restClient.ContentType = "application/vnd.kubernetes.protobuf"
+
+	return kubernetes.NewForConfig(restClient)
+}

--- a/vendor/github.com/GoogleCloudPlatform/prometheus-engine/pkg/secrets/manager.go
+++ b/vendor/github.com/GoogleCloudPlatform/prometheus-engine/pkg/secrets/manager.go
@@ -1,0 +1,243 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secrets
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/yaml.v2"
+)
+
+var (
+	failedSecretConfigs = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "prometheus_kubernetes_failed_secret_configs",
+			Help: "Current number of secret configurations that failed to load.",
+		},
+	)
+	secretsTotal = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "prometheus_kubernetes_secrets_total",
+			Help: "Current number of secrets.",
+		},
+	)
+)
+
+func yamlSerialize(obj any) ([]byte, error) {
+	if obj == nil {
+		return []byte{}, nil
+	}
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	if err := encoder.Encode(obj); err != nil {
+		return nil, err
+	}
+	if err := encoder.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func yamlEqual(x, y any) (bool, error) {
+	yamlX, err := yamlSerialize(x)
+	if err != nil {
+		return false, err
+	}
+	yamlY, err := yamlSerialize(y)
+	if err != nil {
+		return false, err
+	}
+	return bytes.Equal(yamlX, yamlY), nil
+}
+
+// SecretConfig maps a secret name references to a Kubernetes secret.
+type SecretConfig struct {
+	Name   string                 `yaml:"name"`
+	Config KubernetesSecretConfig `yaml:"config"`
+}
+
+type secretEntry struct {
+	config KubernetesSecretConfig
+	secret Secret
+}
+
+// Manager manages the Kubernetes secret provider.
+type Manager struct {
+	ctx  context.Context
+	opts ProviderOptions
+	mtx  sync.Mutex
+
+	cancelFn func()
+	provider *watchProvider
+	config   *WatchSPConfig
+	secrets  map[string]*secretEntry
+}
+
+// NewManager creates a new secret manager with the provided options.
+func NewManager(ctx context.Context, reg prometheus.Registerer, opts ProviderOptions) Manager {
+	if reg != nil {
+		reg.MustRegister(failedSecretConfigs)
+		reg.MustRegister(secretsTotal)
+	}
+	// Note, we do not create the Kubernetes client until we have secrets.
+	return Manager{
+		ctx:      ctx,
+		cancelFn: func() {},
+		secrets:  make(map[string]*secretEntry),
+		opts:     opts,
+	}
+}
+
+// ApplyConfig applies the new secrets, diffing each one with the last configuration to apply the
+// relevant update.
+func (m *Manager) ApplyConfig(providerConfig *WatchSPConfig, configs []SecretConfig) error {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	// If no secrets are provided, cancel any existing secret provider.
+	if len(configs) == 0 {
+		m.cancelFn()
+		m.provider = nil
+		m.cancelFn = func() {}
+		m.secrets = map[string]*secretEntry{}
+		m.config = nil
+		return nil
+	}
+
+	// We must recreate the Kubernetes client and reconnect all secrets if the client configuration
+	// changes. Hypothetically this could be a different API server (or just different parameters).
+	eq, err := yamlEqual(m.config, providerConfig)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		m.config = providerConfig
+	}()
+
+	// We may have an empty Kubernetes configuration (indicating default parameters). Since we don't
+	// have a client until we have secrets, we must create one now, or recreate it if the
+	// configuration changed.
+	if !eq || m.provider == nil {
+		ctx, cancel := context.WithCancel(m.ctx)
+		provider, err := providerConfig.newProvider(ctx, m.opts)
+		if err != nil {
+			cancel()
+			return err
+		}
+
+		m.cancelFn()
+		m.provider = provider
+		m.cancelFn = cancel
+		m.secrets = map[string]*secretEntry{}
+	}
+	return m.updateSecrets(configs)
+}
+
+func (m *Manager) updateSecrets(configs []SecretConfig) error {
+	var errs []error
+
+	// Do a first pass to check for errors and disable those secrets.
+	secretNamesEnabled := make(map[string]bool)
+	for _, secret := range configs {
+		if enabled, ok := secretNamesEnabled[secret.Name]; ok {
+			if !enabled {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("duplicate secret key %q", secret.Name))
+			secretNamesEnabled[secret.Name] = false
+		} else {
+			secretNamesEnabled[secret.Name] = true
+		}
+	}
+
+	secretsFinal := map[string]*secretEntry{}
+	for i := range configs {
+		secretIncoming := &configs[i]
+		if enabled := secretNamesEnabled[secretIncoming.Name]; !enabled {
+			continue
+		}
+		// First check if we've registered this secret before.
+		if secretPrevious, ok := m.secrets[secretIncoming.Name]; ok {
+			// Track all the secrets we saw. The leftover are later removed.
+			delete(m.secrets, secretIncoming.Name)
+
+			// If the config didn't change, we skip this one.
+			eq, err := yamlEqual(&secretPrevious.config, &secretIncoming.Config)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			if eq {
+				secretsFinal[secretIncoming.Name] = secretPrevious
+				continue
+			}
+
+			// The config changed, so update it.
+			s, err := m.provider.Update(&secretPrevious.config, &secretIncoming.Config)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			secretPrevious.secret = s
+			secretsFinal[secretIncoming.Name] = secretPrevious
+		} else {
+			// We've never seen this secret before, so add it.
+			s, err := m.provider.Add(&secretIncoming.Config)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			secretsFinal[secretIncoming.Name] = &secretEntry{
+				config: secretIncoming.Config,
+				secret: s,
+			}
+		}
+	}
+	for _, secretUnused := range m.secrets {
+		m.provider.Remove(&secretUnused.config)
+	}
+
+	m.secrets = secretsFinal
+
+	total := len(secretNamesEnabled)
+	success := len(m.secrets)
+	failedSecretConfigs.Set(float64(total - success))
+	secretsTotal.Set(float64(total))
+	return errors.Join(errs...)
+}
+
+// Fetch implements github.com/prometheus/common/config.SecretManager.Fetch.
+func (m *Manager) Fetch(ctx context.Context, name string) (string, error) {
+	secret, ok := m.secrets[name]
+	if !ok {
+		return "", fmt.Errorf("secret %q not found", name)
+	}
+	return secret.secret.Fetch(ctx)
+}
+
+// Close cancels the manager, stopping the Kubernetes secret provider.
+func (m *Manager) Close(reg prometheus.Registerer) {
+	m.cancelFn()
+	if reg != nil {
+		reg.Unregister(failedSecretConfigs)
+		reg.Unregister(secretsTotal)
+	}
+}

--- a/vendor/github.com/GoogleCloudPlatform/prometheus-engine/pkg/secrets/watch.go
+++ b/vendor/github.com/GoogleCloudPlatform/prometheus-engine/pkg/secrets/watch.go
@@ -1,0 +1,261 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+)
+
+// WatchSPConfig configures access to the Kubernetes API server.
+// TODO(TheSpiritXIII): https://github.com/GoogleCloudPlatform/prometheus-engine/issues/867
+type WatchSPConfig struct {
+	ClientConfig
+}
+
+func (c *WatchSPConfig) newProvider(ctx context.Context, opts ProviderOptions) (*watchProvider, error) {
+	client, err := c.ClientConfig.client()
+	if err != nil {
+		return nil, err
+	}
+	return newWatchProvider(ctx, opts.Logger, client), nil
+}
+
+type secretWatcher struct {
+	// Add, Update and Remove are synchronous. We need to lock everything but `refCount`.
+	mu       sync.Mutex
+	w        watch.Interface
+	s        *corev1.Secret
+	refCount uint
+	done     bool
+}
+
+func newWatcher(ctx context.Context, logger log.Logger, client kubernetes.Interface, config *KubernetesSecretConfig) (*secretWatcher, error) {
+	watcher := &secretWatcher{
+		refCount: 1,
+		done:     false,
+	}
+
+	if err := watcher.start(ctx, client, config); err != nil {
+		return nil, err
+	}
+
+	go func() {
+		for {
+			select {
+			case e, ok := <-watcher.w.ResultChan():
+				if ok {
+					watcher.update(logger, e)
+					continue
+				}
+
+				// If the application shutdown, we don't care about cleanup.
+				if ctx.Err() != nil {
+					watcher.mu.Lock()
+					defer watcher.mu.Lock()
+					watcher.s = nil
+					return
+				}
+				// If closed unintentionally (i.e. network issues), try and restart it.
+				for {
+					ok, err := watcher.restart(ctx, client, config)
+					if ok {
+						return
+					}
+					// If an error occurred trying to watch, keep retrying.
+					if err == nil {
+						break
+					}
+					_ = logger.Log("msg", "unable to restart secret watcher", "err", err, "namespace", watcher.s.Namespace, "name", watcher.s.Name)
+				}
+			case <-ctx.Done():
+				// The application shutdown, we don't care about cleaning up.
+				watcher.close()
+				return
+			}
+		}
+	}()
+
+	return watcher, nil
+}
+
+func (w *secretWatcher) update(logger log.Logger, e watch.Event) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	switch e.Type {
+	case watch.Modified, watch.Added:
+		secret := e.Object.(*corev1.Secret)
+		w.s = secret
+	case watch.Deleted:
+		w.s = nil
+	case watch.Bookmark:
+		// Disabled explicitly when creating the watch interface.
+	case watch.Error:
+		//nolint:errcheck
+		logger.Log("msg", "watch error event", "namespace", w.s.Namespace, "name", w.s.Name)
+	}
+}
+
+func (w *secretWatcher) secret(config *KubernetesSecretConfig) Secret {
+	fn := SecretFn(func(_ context.Context) (string, error) {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		if w.s == nil {
+			return "", fmt.Errorf("secret %s/%s not found", config.Namespace, config.Name)
+		}
+		return getValue(w.s, config.Key)
+	})
+	return &fn
+}
+
+func (w *secretWatcher) start(ctx context.Context, client kubernetes.Interface, config *KubernetesSecretConfig) error {
+	var err error
+	w.w, err = client.CoreV1().Secrets(config.Namespace).Watch(ctx, metav1.ListOptions{
+		FieldSelector:       fields.OneTermEqualSelector(metav1.ObjectNameField, config.Name).String(),
+		AllowWatchBookmarks: false,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to watch secret %s/%s: %w", config.Namespace, config.Name, err)
+	}
+
+	// We could wait for the first watch event, but it doesn't notify us if the resource doesn't exist.
+	w.s, err = client.CoreV1().Secrets(config.Namespace).Get(ctx, config.Name, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("unable to fetch secret %s/%s: %w", config.Namespace, config.Name, err)
+	}
+	return nil
+}
+
+// restart attempts to restart the secret watch. If the watcher is cancelled, we return false after
+// clearing the secret. If the watcher is still running, we return true after restarting the watch.
+func (w *secretWatcher) restart(ctx context.Context, client kubernetes.Interface, config *KubernetesSecretConfig) (bool, error) {
+	// Check in case the channel cancelled intentionally.
+	if w.done {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		w.s = nil
+		return true, nil
+	}
+
+	// Pseudo-arbitrarily jitter the length of the most common scrape interval.
+	jitter := time.Second * time.Duration(1+rand.Intn(30))
+	time.Sleep(1*time.Second + jitter)
+
+	// Lock the watcher so it doesn't cancel before we restart.
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// Check again in case the watcher cancelled while we were waiting for the mutex.
+	if w.done {
+		w.s = nil
+		return true, nil
+	}
+
+	if err := w.start(ctx, client, config); err != nil {
+		return false, err
+	}
+
+	return false, nil
+}
+
+func (w *secretWatcher) close() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.w.Stop()
+	w.s = nil
+}
+
+type watchProvider struct {
+	ctx                context.Context
+	client             kubernetes.Interface
+	secretKeyToWatcher map[string]*secretWatcher
+	logger             log.Logger
+}
+
+func newWatchProvider(ctx context.Context, logger log.Logger, client kubernetes.Interface) *watchProvider {
+	return &watchProvider{
+		ctx:                ctx,
+		client:             client,
+		secretKeyToWatcher: map[string]*secretWatcher{},
+		logger:             logger,
+	}
+}
+
+// Add adds a new secret to the provider, starting a new watch if the secret is not already watched.
+func (p *watchProvider) Add(config *KubernetesSecretConfig) (Secret, error) {
+	objKey := config.objectKey().String()
+	val, ok := p.secretKeyToWatcher[objKey]
+	if ok {
+		val.refCount++
+		return val.secret(config), nil
+	}
+
+	var err error
+	val, err = newWatcher(p.ctx, p.logger, p.client, config)
+	if err != nil {
+		return nil, err
+	}
+
+	p.secretKeyToWatcher[objKey] = val
+	return val.secret(config), nil
+}
+
+// Update updates the secret, restarting the watch if the key changes.
+func (p *watchProvider) Update(configBefore, configAfter *KubernetesSecretConfig) (Secret, error) {
+	objKeyBefore := configBefore.objectKey()
+	objKeyAfter := configAfter.objectKey()
+	if objKeyBefore == objKeyAfter {
+		// If we're using the same secret with a different key, just remap your current watch.
+		val := p.secretKeyToWatcher[objKeyAfter.String()]
+		if val == nil {
+			return nil, fmt.Errorf("secret %s/%s not found", configAfter.Namespace, configAfter.Name)
+		}
+		return val.secret(configAfter), nil
+	}
+	p.Remove(configBefore)
+	return p.Add(configAfter)
+}
+
+// Remove removes the secret, stopping the watch if no other keys for the same secret are watched.
+func (p *watchProvider) Remove(config *KubernetesSecretConfig) {
+	objKey := config.objectKey().String()
+	val := p.secretKeyToWatcher[objKey]
+	if val == nil {
+		return
+	}
+
+	val.refCount--
+	if val.refCount > 0 {
+		return
+	}
+	delete(p.secretKeyToWatcher, objKey)
+
+	val.mu.Lock()
+	defer val.mu.Unlock()
+	val.done = true
+	val.w.Stop()
+}

--- a/vendor/github.com/fsnotify/fsnotify/.cirrus.yml
+++ b/vendor/github.com/fsnotify/fsnotify/.cirrus.yml
@@ -1,0 +1,13 @@
+freebsd_task:
+  name: 'FreeBSD'
+  freebsd_instance:
+    image_family: freebsd-13-2
+  install_script:
+    - pkg update -f
+    - pkg install -y go
+  test_script:
+      # run tests as user "cirrus" instead of root
+    - pw useradd cirrus -m
+    - chown -R cirrus:cirrus .
+    - FSNOTIFY_BUFFER=4096 sudo --preserve-env=FSNOTIFY_BUFFER -u cirrus go test -parallel 1 -race ./...
+    -                      sudo --preserve-env=FSNOTIFY_BUFFER -u cirrus go test -parallel 1 -race ./...

--- a/vendor/github.com/fsnotify/fsnotify/.gitignore
+++ b/vendor/github.com/fsnotify/fsnotify/.gitignore
@@ -4,3 +4,4 @@
 
 # Output of go build ./cmd/fsnotify
 /fsnotify
+/fsnotify.exe

--- a/vendor/github.com/fsnotify/fsnotify/backend_fen.go
+++ b/vendor/github.com/fsnotify/fsnotify/backend_fen.go
@@ -1,10 +1,19 @@
 //go:build solaris
 // +build solaris
 
+// Note: the documentation on the Watcher type and methods is generated from
+// mkdoc.zsh
+
 package fsnotify
 
 import (
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"golang.org/x/sys/unix"
 )
 
 // Watcher watches a set of paths, delivering events on a channel.
@@ -17,9 +26,9 @@ import (
 // When a file is removed a Remove event won't be emitted until all file
 // descriptors are closed, and deletes will always emit a Chmod. For example:
 //
-//     fp := os.Open("file")
-//     os.Remove("file")        // Triggers Chmod
-//     fp.Close()               // Triggers Remove
+//	fp := os.Open("file")
+//	os.Remove("file")        // Triggers Chmod
+//	fp.Close()               // Triggers Remove
 //
 // This is the event that inotify sends, so not much can be changed about this.
 //
@@ -33,16 +42,16 @@ import (
 //
 // To increase them you can use sysctl or write the value to the /proc file:
 //
-//     # Default values on Linux 5.18
-//     sysctl fs.inotify.max_user_watches=124983
-//     sysctl fs.inotify.max_user_instances=128
+//	# Default values on Linux 5.18
+//	sysctl fs.inotify.max_user_watches=124983
+//	sysctl fs.inotify.max_user_instances=128
 //
 // To make the changes persist on reboot edit /etc/sysctl.conf or
 // /usr/lib/sysctl.d/50-default.conf (details differ per Linux distro; check
 // your distro's documentation):
 //
-//     fs.inotify.max_user_watches=124983
-//     fs.inotify.max_user_instances=128
+//	fs.inotify.max_user_watches=124983
+//	fs.inotify.max_user_instances=128
 //
 // Reaching the limit will result in a "no space left on device" or "too many open
 // files" error.
@@ -58,14 +67,20 @@ import (
 // control the maximum number of open files, as well as /etc/login.conf on BSD
 // systems.
 //
-// # macOS notes
+// # Windows notes
 //
-// Spotlight indexing on macOS can result in multiple events (see [#15]). A
-// temporary workaround is to add your folder(s) to the "Spotlight Privacy
-// Settings" until we have a native FSEvents implementation (see [#11]).
+// Paths can be added as "C:\path\to\dir", but forward slashes
+// ("C:/path/to/dir") will also work.
 //
-// [#11]: https://github.com/fsnotify/fsnotify/issues/11
-// [#15]: https://github.com/fsnotify/fsnotify/issues/15
+// When a watched directory is removed it will always send an event for the
+// directory itself, but may not send events for all files in that directory.
+// Sometimes it will send events for all times, sometimes it will send no
+// events, and often only for some files.
+//
+// The default ReadDirectoryChangesW() buffer size is 64K, which is the largest
+// value that is guaranteed to work with SMB filesystems. If you have many
+// events in quick succession this may not be enough, and you will have to use
+// [WithBufferSize] to increase the value.
 type Watcher struct {
 	// Events sends the filesystem change events.
 	//
@@ -92,43 +107,128 @@ type Watcher struct {
 	//                      initiated by the user may show up as one or multiple
 	//                      writes, depending on when the system syncs things to
 	//                      disk. For example when compiling a large Go program
-	//                      you may get hundreds of Write events, so you
-	//                      probably want to wait until you've stopped receiving
-	//                      them (see the dedup example in cmd/fsnotify).
+	//                      you may get hundreds of Write events, and you may
+	//                      want to wait until you've stopped receiving them
+	//                      (see the dedup example in cmd/fsnotify).
+	//
+	//                      Some systems may send Write event for directories
+	//                      when the directory content changes.
 	//
 	//   fsnotify.Chmod     Attributes were changed. On Linux this is also sent
 	//                      when a file is removed (or more accurately, when a
 	//                      link to an inode is removed). On kqueue it's sent
-	//                      and on kqueue when a file is truncated. On Windows
-	//                      it's never sent.
+	//                      when a file is truncated. On Windows it's never
+	//                      sent.
 	Events chan Event
 
 	// Errors sends any errors.
+	//
+	// ErrEventOverflow is used to indicate there are too many events:
+	//
+	//  - inotify:      There are too many queued events (fs.inotify.max_queued_events sysctl)
+	//  - windows:      The buffer size is too small; WithBufferSize() can be used to increase it.
+	//  - kqueue, fen:  Not used.
 	Errors chan error
+
+	mu      sync.Mutex
+	port    *unix.EventPort
+	done    chan struct{}       // Channel for sending a "quit message" to the reader goroutine
+	dirs    map[string]struct{} // Explicitly watched directories
+	watches map[string]struct{} // Explicitly watched non-directories
 }
 
 // NewWatcher creates a new Watcher.
 func NewWatcher() (*Watcher, error) {
-	return nil, errors.New("FEN based watcher not yet supported for fsnotify\n")
+	return NewBufferedWatcher(0)
 }
 
-// Close removes all watches and closes the events channel.
+// NewBufferedWatcher creates a new Watcher with a buffered Watcher.Events
+// channel.
+//
+// The main use case for this is situations with a very large number of events
+// where the kernel buffer size can't be increased (e.g. due to lack of
+// permissions). An unbuffered Watcher will perform better for almost all use
+// cases, and whenever possible you will be better off increasing the kernel
+// buffers instead of adding a large userspace buffer.
+func NewBufferedWatcher(sz uint) (*Watcher, error) {
+	w := &Watcher{
+		Events:  make(chan Event, sz),
+		Errors:  make(chan error),
+		dirs:    make(map[string]struct{}),
+		watches: make(map[string]struct{}),
+		done:    make(chan struct{}),
+	}
+
+	var err error
+	w.port, err = unix.NewEventPort()
+	if err != nil {
+		return nil, fmt.Errorf("fsnotify.NewWatcher: %w", err)
+	}
+
+	go w.readEvents()
+	return w, nil
+}
+
+// sendEvent attempts to send an event to the user, returning true if the event
+// was put in the channel successfully and false if the watcher has been closed.
+func (w *Watcher) sendEvent(name string, op Op) (sent bool) {
+	select {
+	case w.Events <- Event{Name: name, Op: op}:
+		return true
+	case <-w.done:
+		return false
+	}
+}
+
+// sendError attempts to send an error to the user, returning true if the error
+// was put in the channel successfully and false if the watcher has been closed.
+func (w *Watcher) sendError(err error) (sent bool) {
+	select {
+	case w.Errors <- err:
+		return true
+	case <-w.done:
+		return false
+	}
+}
+
+func (w *Watcher) isClosed() bool {
+	select {
+	case <-w.done:
+		return true
+	default:
+		return false
+	}
+}
+
+// Close removes all watches and closes the Events channel.
 func (w *Watcher) Close() error {
-	return nil
+	// Take the lock used by associateFile to prevent lingering events from
+	// being processed after the close
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.isClosed() {
+		return nil
+	}
+	close(w.done)
+	return w.port.Close()
 }
 
 // Add starts monitoring the path for changes.
 //
-// A path can only be watched once; attempting to watch it more than once will
-// return an error. Paths that do not yet exist on the filesystem cannot be
-// added. A watch will be automatically removed if the path is deleted.
+// A path can only be watched once; watching it more than once is a no-op and will
+// not return an error. Paths that do not yet exist on the filesystem cannot be
+// watched.
 //
-// A path will remain watched if it gets renamed to somewhere else on the same
-// filesystem, but the monitor will get removed if the path gets deleted and
-// re-created, or if it's moved to a different filesystem.
+// A watch will be automatically removed if the watched path is deleted or
+// renamed. The exception is the Windows backend, which doesn't remove the
+// watcher on renames.
 //
 // Notifications on network filesystems (NFS, SMB, FUSE, etc.) or special
 // filesystems (/proc, /sys, etc.) generally don't work.
+//
+// Returns [ErrClosed] if [Watcher.Close] was called.
+//
+// See [Watcher.AddWith] for a version that allows adding options.
 //
 // # Watching directories
 //
@@ -139,15 +239,63 @@ func (w *Watcher) Close() error {
 // # Watching files
 //
 // Watching individual files (rather than directories) is generally not
-// recommended as many tools update files atomically. Instead of "just" writing
-// to the file a temporary file will be written to first, and if successful the
-// temporary file is moved to to destination removing the original, or some
-// variant thereof. The watcher on the original file is now lost, as it no
-// longer exists.
+// recommended as many programs (especially editors) update files atomically: it
+// will write to a temporary file which is then moved to to destination,
+// overwriting the original (or some variant thereof). The watcher on the
+// original file is now lost, as that no longer exists.
 //
-// Instead, watch the parent directory and use Event.Name to filter out files
-// you're not interested in. There is an example of this in [cmd/fsnotify/file.go].
-func (w *Watcher) Add(name string) error {
+// The upshot of this is that a power failure or crash won't leave a
+// half-written file.
+//
+// Watch the parent directory and use Event.Name to filter out files you're not
+// interested in. There is an example of this in cmd/fsnotify/file.go.
+func (w *Watcher) Add(name string) error { return w.AddWith(name) }
+
+// AddWith is like [Watcher.Add], but allows adding options. When using Add()
+// the defaults described below are used.
+//
+// Possible options are:
+//
+//   - [WithBufferSize] sets the buffer size for the Windows backend; no-op on
+//     other platforms. The default is 64K (65536 bytes).
+func (w *Watcher) AddWith(name string, opts ...addOpt) error {
+	if w.isClosed() {
+		return ErrClosed
+	}
+	if w.port.PathIsWatched(name) {
+		return nil
+	}
+
+	_ = getOptions(opts...)
+
+	// Currently we resolve symlinks that were explicitly requested to be
+	// watched. Otherwise we would use LStat here.
+	stat, err := os.Stat(name)
+	if err != nil {
+		return err
+	}
+
+	// Associate all files in the directory.
+	if stat.IsDir() {
+		err := w.handleDirectory(name, stat, true, w.associateFile)
+		if err != nil {
+			return err
+		}
+
+		w.mu.Lock()
+		w.dirs[name] = struct{}{}
+		w.mu.Unlock()
+		return nil
+	}
+
+	err = w.associateFile(name, stat, true)
+	if err != nil {
+		return err
+	}
+
+	w.mu.Lock()
+	w.watches[name] = struct{}{}
+	w.mu.Unlock()
 	return nil
 }
 
@@ -157,6 +305,336 @@ func (w *Watcher) Add(name string) error {
 // /tmp/dir and /tmp/dir/subdir then you will need to remove both.
 //
 // Removing a path that has not yet been added returns [ErrNonExistentWatch].
+//
+// Returns nil if [Watcher.Close] was called.
 func (w *Watcher) Remove(name string) error {
+	if w.isClosed() {
+		return nil
+	}
+	if !w.port.PathIsWatched(name) {
+		return fmt.Errorf("%w: %s", ErrNonExistentWatch, name)
+	}
+
+	// The user has expressed an intent. Immediately remove this name from
+	// whichever watch list it might be in. If it's not in there the delete
+	// doesn't cause harm.
+	w.mu.Lock()
+	delete(w.watches, name)
+	delete(w.dirs, name)
+	w.mu.Unlock()
+
+	stat, err := os.Stat(name)
+	if err != nil {
+		return err
+	}
+
+	// Remove associations for every file in the directory.
+	if stat.IsDir() {
+		err := w.handleDirectory(name, stat, false, w.dissociateFile)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	err = w.port.DissociatePath(name)
+	if err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// readEvents contains the main loop that runs in a goroutine watching for events.
+func (w *Watcher) readEvents() {
+	// If this function returns, the watcher has been closed and we can close
+	// these channels
+	defer func() {
+		close(w.Errors)
+		close(w.Events)
+	}()
+
+	pevents := make([]unix.PortEvent, 8)
+	for {
+		count, err := w.port.Get(pevents, 1, nil)
+		if err != nil && err != unix.ETIME {
+			// Interrupted system call (count should be 0) ignore and continue
+			if errors.Is(err, unix.EINTR) && count == 0 {
+				continue
+			}
+			// Get failed because we called w.Close()
+			if errors.Is(err, unix.EBADF) && w.isClosed() {
+				return
+			}
+			// There was an error not caused by calling w.Close()
+			if !w.sendError(err) {
+				return
+			}
+		}
+
+		p := pevents[:count]
+		for _, pevent := range p {
+			if pevent.Source != unix.PORT_SOURCE_FILE {
+				// Event from unexpected source received; should never happen.
+				if !w.sendError(errors.New("Event from unexpected source received")) {
+					return
+				}
+				continue
+			}
+
+			err = w.handleEvent(&pevent)
+			if err != nil {
+				if !w.sendError(err) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func (w *Watcher) handleDirectory(path string, stat os.FileInfo, follow bool, handler func(string, os.FileInfo, bool) error) error {
+	files, err := os.ReadDir(path)
+	if err != nil {
+		return err
+	}
+
+	// Handle all children of the directory.
+	for _, entry := range files {
+		finfo, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		err = handler(filepath.Join(path, finfo.Name()), finfo, false)
+		if err != nil {
+			return err
+		}
+	}
+
+	// And finally handle the directory itself.
+	return handler(path, stat, follow)
+}
+
+// handleEvent might need to emit more than one fsnotify event if the events
+// bitmap matches more than one event type (e.g. the file was both modified and
+// had the attributes changed between when the association was created and the
+// when event was returned)
+func (w *Watcher) handleEvent(event *unix.PortEvent) error {
+	var (
+		events     = event.Events
+		path       = event.Path
+		fmode      = event.Cookie.(os.FileMode)
+		reRegister = true
+	)
+
+	w.mu.Lock()
+	_, watchedDir := w.dirs[path]
+	_, watchedPath := w.watches[path]
+	w.mu.Unlock()
+	isWatched := watchedDir || watchedPath
+
+	if events&unix.FILE_DELETE != 0 {
+		if !w.sendEvent(path, Remove) {
+			return nil
+		}
+		reRegister = false
+	}
+	if events&unix.FILE_RENAME_FROM != 0 {
+		if !w.sendEvent(path, Rename) {
+			return nil
+		}
+		// Don't keep watching the new file name
+		reRegister = false
+	}
+	if events&unix.FILE_RENAME_TO != 0 {
+		// We don't report a Rename event for this case, because Rename events
+		// are interpreted as referring to the _old_ name of the file, and in
+		// this case the event would refer to the new name of the file. This
+		// type of rename event is not supported by fsnotify.
+
+		// inotify reports a Remove event in this case, so we simulate this
+		// here.
+		if !w.sendEvent(path, Remove) {
+			return nil
+		}
+		// Don't keep watching the file that was removed
+		reRegister = false
+	}
+
+	// The file is gone, nothing left to do.
+	if !reRegister {
+		if watchedDir {
+			w.mu.Lock()
+			delete(w.dirs, path)
+			w.mu.Unlock()
+		}
+		if watchedPath {
+			w.mu.Lock()
+			delete(w.watches, path)
+			w.mu.Unlock()
+		}
+		return nil
+	}
+
+	// If we didn't get a deletion the file still exists and we're going to have
+	// to watch it again. Let's Stat it now so that we can compare permissions
+	// and have what we need to continue watching the file
+
+	stat, err := os.Lstat(path)
+	if err != nil {
+		// This is unexpected, but we should still emit an event. This happens
+		// most often on "rm -r" of a subdirectory inside a watched directory We
+		// get a modify event of something happening inside, but by the time we
+		// get here, the sudirectory is already gone. Clearly we were watching
+		// this path but now it is gone. Let's tell the user that it was
+		// removed.
+		if !w.sendEvent(path, Remove) {
+			return nil
+		}
+		// Suppress extra write events on removed directories; they are not
+		// informative and can be confusing.
+		return nil
+	}
+
+	// resolve symlinks that were explicitly watched as we would have at Add()
+	// time. this helps suppress spurious Chmod events on watched symlinks
+	if isWatched {
+		stat, err = os.Stat(path)
+		if err != nil {
+			// The symlink still exists, but the target is gone. Report the
+			// Remove similar to above.
+			if !w.sendEvent(path, Remove) {
+				return nil
+			}
+			// Don't return the error
+		}
+	}
+
+	if events&unix.FILE_MODIFIED != 0 {
+		if fmode.IsDir() {
+			if watchedDir {
+				if err := w.updateDirectory(path); err != nil {
+					return err
+				}
+			} else {
+				if !w.sendEvent(path, Write) {
+					return nil
+				}
+			}
+		} else {
+			if !w.sendEvent(path, Write) {
+				return nil
+			}
+		}
+	}
+	if events&unix.FILE_ATTRIB != 0 && stat != nil {
+		// Only send Chmod if perms changed
+		if stat.Mode().Perm() != fmode.Perm() {
+			if !w.sendEvent(path, Chmod) {
+				return nil
+			}
+		}
+	}
+
+	if stat != nil {
+		// If we get here, it means we've hit an event above that requires us to
+		// continue watching the file or directory
+		return w.associateFile(path, stat, isWatched)
+	}
+	return nil
+}
+
+func (w *Watcher) updateDirectory(path string) error {
+	// The directory was modified, so we must find unwatched entities and watch
+	// them. If something was removed from the directory, nothing will happen,
+	// as everything else should still be watched.
+	files, err := os.ReadDir(path)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range files {
+		path := filepath.Join(path, entry.Name())
+		if w.port.PathIsWatched(path) {
+			continue
+		}
+
+		finfo, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		err = w.associateFile(path, finfo, false)
+		if err != nil {
+			if !w.sendError(err) {
+				return nil
+			}
+		}
+		if !w.sendEvent(path, Create) {
+			return nil
+		}
+	}
+	return nil
+}
+
+func (w *Watcher) associateFile(path string, stat os.FileInfo, follow bool) error {
+	if w.isClosed() {
+		return ErrClosed
+	}
+	// This is primarily protecting the call to AssociatePath but it is
+	// important and intentional that the call to PathIsWatched is also
+	// protected by this mutex. Without this mutex, AssociatePath has been seen
+	// to error out that the path is already associated.
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.port.PathIsWatched(path) {
+		// Remove the old association in favor of this one If we get ENOENT,
+		// then while the x/sys/unix wrapper still thought that this path was
+		// associated, the underlying event port did not. This call will have
+		// cleared up that discrepancy. The most likely cause is that the event
+		// has fired but we haven't processed it yet.
+		err := w.port.DissociatePath(path)
+		if err != nil && err != unix.ENOENT {
+			return err
+		}
+	}
+	// FILE_NOFOLLOW means we watch symlinks themselves rather than their
+	// targets.
+	events := unix.FILE_MODIFIED | unix.FILE_ATTRIB | unix.FILE_NOFOLLOW
+	if follow {
+		// We *DO* follow symlinks for explicitly watched entries.
+		events = unix.FILE_MODIFIED | unix.FILE_ATTRIB
+	}
+	return w.port.AssociatePath(path, stat,
+		events,
+		stat.Mode())
+}
+
+func (w *Watcher) dissociateFile(path string, stat os.FileInfo, unused bool) error {
+	if !w.port.PathIsWatched(path) {
+		return nil
+	}
+	return w.port.DissociatePath(path)
+}
+
+// WatchList returns all paths explicitly added with [Watcher.Add] (and are not
+// yet removed).
+//
+// Returns nil if [Watcher.Close] was called.
+func (w *Watcher) WatchList() []string {
+	if w.isClosed() {
+		return nil
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	entries := make([]string, 0, len(w.watches)+len(w.dirs))
+	for pathname := range w.dirs {
+		entries = append(entries, pathname)
+	}
+	for pathname := range w.watches {
+		entries = append(entries, pathname)
+	}
+
+	return entries
 }

--- a/vendor/github.com/fsnotify/fsnotify/backend_other.go
+++ b/vendor/github.com/fsnotify/fsnotify/backend_other.go
@@ -1,38 +1,168 @@
-//go:build !darwin && !dragonfly && !freebsd && !openbsd && !linux && !netbsd && !solaris && !windows
-// +build !darwin,!dragonfly,!freebsd,!openbsd,!linux,!netbsd,!solaris,!windows
+//go:build appengine || (!darwin && !dragonfly && !freebsd && !openbsd && !linux && !netbsd && !solaris && !windows)
+// +build appengine !darwin,!dragonfly,!freebsd,!openbsd,!linux,!netbsd,!solaris,!windows
+
+// Note: the documentation on the Watcher type and methods is generated from
+// mkdoc.zsh
 
 package fsnotify
 
-import (
-	"fmt"
-	"runtime"
-)
+import "errors"
 
-// Watcher watches a set of files, delivering events to a channel.
-type Watcher struct{}
+// Watcher watches a set of paths, delivering events on a channel.
+//
+// A watcher should not be copied (e.g. pass it by pointer, rather than by
+// value).
+//
+// # Linux notes
+//
+// When a file is removed a Remove event won't be emitted until all file
+// descriptors are closed, and deletes will always emit a Chmod. For example:
+//
+//	fp := os.Open("file")
+//	os.Remove("file")        // Triggers Chmod
+//	fp.Close()               // Triggers Remove
+//
+// This is the event that inotify sends, so not much can be changed about this.
+//
+// The fs.inotify.max_user_watches sysctl variable specifies the upper limit
+// for the number of watches per user, and fs.inotify.max_user_instances
+// specifies the maximum number of inotify instances per user. Every Watcher you
+// create is an "instance", and every path you add is a "watch".
+//
+// These are also exposed in /proc as /proc/sys/fs/inotify/max_user_watches and
+// /proc/sys/fs/inotify/max_user_instances
+//
+// To increase them you can use sysctl or write the value to the /proc file:
+//
+//	# Default values on Linux 5.18
+//	sysctl fs.inotify.max_user_watches=124983
+//	sysctl fs.inotify.max_user_instances=128
+//
+// To make the changes persist on reboot edit /etc/sysctl.conf or
+// /usr/lib/sysctl.d/50-default.conf (details differ per Linux distro; check
+// your distro's documentation):
+//
+//	fs.inotify.max_user_watches=124983
+//	fs.inotify.max_user_instances=128
+//
+// Reaching the limit will result in a "no space left on device" or "too many open
+// files" error.
+//
+// # kqueue notes (macOS, BSD)
+//
+// kqueue requires opening a file descriptor for every file that's being watched;
+// so if you're watching a directory with five files then that's six file
+// descriptors. You will run in to your system's "max open files" limit faster on
+// these platforms.
+//
+// The sysctl variables kern.maxfiles and kern.maxfilesperproc can be used to
+// control the maximum number of open files, as well as /etc/login.conf on BSD
+// systems.
+//
+// # Windows notes
+//
+// Paths can be added as "C:\path\to\dir", but forward slashes
+// ("C:/path/to/dir") will also work.
+//
+// When a watched directory is removed it will always send an event for the
+// directory itself, but may not send events for all files in that directory.
+// Sometimes it will send events for all times, sometimes it will send no
+// events, and often only for some files.
+//
+// The default ReadDirectoryChangesW() buffer size is 64K, which is the largest
+// value that is guaranteed to work with SMB filesystems. If you have many
+// events in quick succession this may not be enough, and you will have to use
+// [WithBufferSize] to increase the value.
+type Watcher struct {
+	// Events sends the filesystem change events.
+	//
+	// fsnotify can send the following events; a "path" here can refer to a
+	// file, directory, symbolic link, or special file like a FIFO.
+	//
+	//   fsnotify.Create    A new path was created; this may be followed by one
+	//                      or more Write events if data also gets written to a
+	//                      file.
+	//
+	//   fsnotify.Remove    A path was removed.
+	//
+	//   fsnotify.Rename    A path was renamed. A rename is always sent with the
+	//                      old path as Event.Name, and a Create event will be
+	//                      sent with the new name. Renames are only sent for
+	//                      paths that are currently watched; e.g. moving an
+	//                      unmonitored file into a monitored directory will
+	//                      show up as just a Create. Similarly, renaming a file
+	//                      to outside a monitored directory will show up as
+	//                      only a Rename.
+	//
+	//   fsnotify.Write     A file or named pipe was written to. A Truncate will
+	//                      also trigger a Write. A single "write action"
+	//                      initiated by the user may show up as one or multiple
+	//                      writes, depending on when the system syncs things to
+	//                      disk. For example when compiling a large Go program
+	//                      you may get hundreds of Write events, and you may
+	//                      want to wait until you've stopped receiving them
+	//                      (see the dedup example in cmd/fsnotify).
+	//
+	//                      Some systems may send Write event for directories
+	//                      when the directory content changes.
+	//
+	//   fsnotify.Chmod     Attributes were changed. On Linux this is also sent
+	//                      when a file is removed (or more accurately, when a
+	//                      link to an inode is removed). On kqueue it's sent
+	//                      when a file is truncated. On Windows it's never
+	//                      sent.
+	Events chan Event
+
+	// Errors sends any errors.
+	//
+	// ErrEventOverflow is used to indicate there are too many events:
+	//
+	//  - inotify:      There are too many queued events (fs.inotify.max_queued_events sysctl)
+	//  - windows:      The buffer size is too small; WithBufferSize() can be used to increase it.
+	//  - kqueue, fen:  Not used.
+	Errors chan error
+}
 
 // NewWatcher creates a new Watcher.
 func NewWatcher() (*Watcher, error) {
-	return nil, fmt.Errorf("fsnotify not supported on %s", runtime.GOOS)
+	return nil, errors.New("fsnotify not supported on the current platform")
 }
 
-// Close removes all watches and closes the events channel.
-func (w *Watcher) Close() error {
-	return nil
-}
+// NewBufferedWatcher creates a new Watcher with a buffered Watcher.Events
+// channel.
+//
+// The main use case for this is situations with a very large number of events
+// where the kernel buffer size can't be increased (e.g. due to lack of
+// permissions). An unbuffered Watcher will perform better for almost all use
+// cases, and whenever possible you will be better off increasing the kernel
+// buffers instead of adding a large userspace buffer.
+func NewBufferedWatcher(sz uint) (*Watcher, error) { return NewWatcher() }
+
+// Close removes all watches and closes the Events channel.
+func (w *Watcher) Close() error { return nil }
+
+// WatchList returns all paths explicitly added with [Watcher.Add] (and are not
+// yet removed).
+//
+// Returns nil if [Watcher.Close] was called.
+func (w *Watcher) WatchList() []string { return nil }
 
 // Add starts monitoring the path for changes.
 //
-// A path can only be watched once; attempting to watch it more than once will
-// return an error. Paths that do not yet exist on the filesystem cannot be
-// added. A watch will be automatically removed if the path is deleted.
+// A path can only be watched once; watching it more than once is a no-op and will
+// not return an error. Paths that do not yet exist on the filesystem cannot be
+// watched.
 //
-// A path will remain watched if it gets renamed to somewhere else on the same
-// filesystem, but the monitor will get removed if the path gets deleted and
-// re-created, or if it's moved to a different filesystem.
+// A watch will be automatically removed if the watched path is deleted or
+// renamed. The exception is the Windows backend, which doesn't remove the
+// watcher on renames.
 //
 // Notifications on network filesystems (NFS, SMB, FUSE, etc.) or special
 // filesystems (/proc, /sys, etc.) generally don't work.
+//
+// Returns [ErrClosed] if [Watcher.Close] was called.
+//
+// See [Watcher.AddWith] for a version that allows adding options.
 //
 // # Watching directories
 //
@@ -43,17 +173,26 @@ func (w *Watcher) Close() error {
 // # Watching files
 //
 // Watching individual files (rather than directories) is generally not
-// recommended as many tools update files atomically. Instead of "just" writing
-// to the file a temporary file will be written to first, and if successful the
-// temporary file is moved to to destination removing the original, or some
-// variant thereof. The watcher on the original file is now lost, as it no
-// longer exists.
+// recommended as many programs (especially editors) update files atomically: it
+// will write to a temporary file which is then moved to to destination,
+// overwriting the original (or some variant thereof). The watcher on the
+// original file is now lost, as that no longer exists.
 //
-// Instead, watch the parent directory and use Event.Name to filter out files
-// you're not interested in. There is an example of this in [cmd/fsnotify/file.go].
-func (w *Watcher) Add(name string) error {
-	return nil
-}
+// The upshot of this is that a power failure or crash won't leave a
+// half-written file.
+//
+// Watch the parent directory and use Event.Name to filter out files you're not
+// interested in. There is an example of this in cmd/fsnotify/file.go.
+func (w *Watcher) Add(name string) error { return nil }
+
+// AddWith is like [Watcher.Add], but allows adding options. When using Add()
+// the defaults described below are used.
+//
+// Possible options are:
+//
+//   - [WithBufferSize] sets the buffer size for the Windows backend; no-op on
+//     other platforms. The default is 64K (65536 bytes).
+func (w *Watcher) AddWith(name string, opts ...addOpt) error { return nil }
 
 // Remove stops monitoring the path for changes.
 //
@@ -61,6 +200,6 @@ func (w *Watcher) Add(name string) error {
 // /tmp/dir and /tmp/dir/subdir then you will need to remove both.
 //
 // Removing a path that has not yet been added returns [ErrNonExistentWatch].
-func (w *Watcher) Remove(name string) error {
-	return nil
-}
+//
+// Returns nil if [Watcher.Close] was called.
+func (w *Watcher) Remove(name string) error { return nil }

--- a/vendor/github.com/fsnotify/fsnotify/backend_windows.go
+++ b/vendor/github.com/fsnotify/fsnotify/backend_windows.go
@@ -1,6 +1,13 @@
 //go:build windows
 // +build windows
 
+// Windows backend based on ReadDirectoryChangesW()
+//
+// https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-readdirectorychangesw
+//
+// Note: the documentation on the Watcher type and methods is generated from
+// mkdoc.zsh
+
 package fsnotify
 
 import (
@@ -27,9 +34,9 @@ import (
 // When a file is removed a Remove event won't be emitted until all file
 // descriptors are closed, and deletes will always emit a Chmod. For example:
 //
-//     fp := os.Open("file")
-//     os.Remove("file")        // Triggers Chmod
-//     fp.Close()               // Triggers Remove
+//	fp := os.Open("file")
+//	os.Remove("file")        // Triggers Chmod
+//	fp.Close()               // Triggers Remove
 //
 // This is the event that inotify sends, so not much can be changed about this.
 //
@@ -43,16 +50,16 @@ import (
 //
 // To increase them you can use sysctl or write the value to the /proc file:
 //
-//     # Default values on Linux 5.18
-//     sysctl fs.inotify.max_user_watches=124983
-//     sysctl fs.inotify.max_user_instances=128
+//	# Default values on Linux 5.18
+//	sysctl fs.inotify.max_user_watches=124983
+//	sysctl fs.inotify.max_user_instances=128
 //
 // To make the changes persist on reboot edit /etc/sysctl.conf or
 // /usr/lib/sysctl.d/50-default.conf (details differ per Linux distro; check
 // your distro's documentation):
 //
-//     fs.inotify.max_user_watches=124983
-//     fs.inotify.max_user_instances=128
+//	fs.inotify.max_user_watches=124983
+//	fs.inotify.max_user_instances=128
 //
 // Reaching the limit will result in a "no space left on device" or "too many open
 // files" error.
@@ -68,14 +75,20 @@ import (
 // control the maximum number of open files, as well as /etc/login.conf on BSD
 // systems.
 //
-// # macOS notes
+// # Windows notes
 //
-// Spotlight indexing on macOS can result in multiple events (see [#15]). A
-// temporary workaround is to add your folder(s) to the "Spotlight Privacy
-// Settings" until we have a native FSEvents implementation (see [#11]).
+// Paths can be added as "C:\path\to\dir", but forward slashes
+// ("C:/path/to/dir") will also work.
 //
-// [#11]: https://github.com/fsnotify/fsnotify/issues/11
-// [#15]: https://github.com/fsnotify/fsnotify/issues/15
+// When a watched directory is removed it will always send an event for the
+// directory itself, but may not send events for all files in that directory.
+// Sometimes it will send events for all times, sometimes it will send no
+// events, and often only for some files.
+//
+// The default ReadDirectoryChangesW() buffer size is 64K, which is the largest
+// value that is guaranteed to work with SMB filesystems. If you have many
+// events in quick succession this may not be enough, and you will have to use
+// [WithBufferSize] to increase the value.
 type Watcher struct {
 	// Events sends the filesystem change events.
 	//
@@ -102,31 +115,52 @@ type Watcher struct {
 	//                      initiated by the user may show up as one or multiple
 	//                      writes, depending on when the system syncs things to
 	//                      disk. For example when compiling a large Go program
-	//                      you may get hundreds of Write events, so you
-	//                      probably want to wait until you've stopped receiving
-	//                      them (see the dedup example in cmd/fsnotify).
+	//                      you may get hundreds of Write events, and you may
+	//                      want to wait until you've stopped receiving them
+	//                      (see the dedup example in cmd/fsnotify).
+	//
+	//                      Some systems may send Write event for directories
+	//                      when the directory content changes.
 	//
 	//   fsnotify.Chmod     Attributes were changed. On Linux this is also sent
 	//                      when a file is removed (or more accurately, when a
 	//                      link to an inode is removed). On kqueue it's sent
-	//                      and on kqueue when a file is truncated. On Windows
-	//                      it's never sent.
+	//                      when a file is truncated. On Windows it's never
+	//                      sent.
 	Events chan Event
 
 	// Errors sends any errors.
+	//
+	// ErrEventOverflow is used to indicate there are too many events:
+	//
+	//  - inotify:      There are too many queued events (fs.inotify.max_queued_events sysctl)
+	//  - windows:      The buffer size is too small; WithBufferSize() can be used to increase it.
+	//  - kqueue, fen:  Not used.
 	Errors chan error
 
 	port  windows.Handle // Handle to completion port
 	input chan *input    // Inputs to the reader are sent on this channel
 	quit  chan chan<- error
 
-	mu       sync.Mutex // Protects access to watches, isClosed
-	watches  watchMap   // Map of watches (key: i-number)
-	isClosed bool       // Set to true when Close() is first called
+	mu      sync.Mutex // Protects access to watches, closed
+	watches watchMap   // Map of watches (key: i-number)
+	closed  bool       // Set to true when Close() is first called
 }
 
 // NewWatcher creates a new Watcher.
 func NewWatcher() (*Watcher, error) {
+	return NewBufferedWatcher(50)
+}
+
+// NewBufferedWatcher creates a new Watcher with a buffered Watcher.Events
+// channel.
+//
+// The main use case for this is situations with a very large number of events
+// where the kernel buffer size can't be increased (e.g. due to lack of
+// permissions). An unbuffered Watcher will perform better for almost all use
+// cases, and whenever possible you will be better off increasing the kernel
+// buffers instead of adding a large userspace buffer.
+func NewBufferedWatcher(sz uint) (*Watcher, error) {
 	port, err := windows.CreateIoCompletionPort(windows.InvalidHandle, 0, 0, 0)
 	if err != nil {
 		return nil, os.NewSyscallError("CreateIoCompletionPort", err)
@@ -135,12 +169,18 @@ func NewWatcher() (*Watcher, error) {
 		port:    port,
 		watches: make(watchMap),
 		input:   make(chan *input, 1),
-		Events:  make(chan Event, 50),
+		Events:  make(chan Event, sz),
 		Errors:  make(chan error),
 		quit:    make(chan chan<- error, 1),
 	}
 	go w.readEvents()
 	return w, nil
+}
+
+func (w *Watcher) isClosed() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.closed
 }
 
 func (w *Watcher) sendEvent(name string, mask uint64) bool {
@@ -167,14 +207,14 @@ func (w *Watcher) sendError(err error) bool {
 	return false
 }
 
-// Close removes all watches and closes the events channel.
+// Close removes all watches and closes the Events channel.
 func (w *Watcher) Close() error {
-	w.mu.Lock()
-	if w.isClosed {
-		w.mu.Unlock()
+	if w.isClosed() {
 		return nil
 	}
-	w.isClosed = true
+
+	w.mu.Lock()
+	w.closed = true
 	w.mu.Unlock()
 
 	// Send "quit" message to the reader goroutine
@@ -188,16 +228,20 @@ func (w *Watcher) Close() error {
 
 // Add starts monitoring the path for changes.
 //
-// A path can only be watched once; attempting to watch it more than once will
-// return an error. Paths that do not yet exist on the filesystem cannot be
-// added. A watch will be automatically removed if the path is deleted.
+// A path can only be watched once; watching it more than once is a no-op and will
+// not return an error. Paths that do not yet exist on the filesystem cannot be
+// watched.
 //
-// A path will remain watched if it gets renamed to somewhere else on the same
-// filesystem, but the monitor will get removed if the path gets deleted and
-// re-created, or if it's moved to a different filesystem.
+// A watch will be automatically removed if the watched path is deleted or
+// renamed. The exception is the Windows backend, which doesn't remove the
+// watcher on renames.
 //
 // Notifications on network filesystems (NFS, SMB, FUSE, etc.) or special
 // filesystems (/proc, /sys, etc.) generally don't work.
+//
+// Returns [ErrClosed] if [Watcher.Close] was called.
+//
+// See [Watcher.AddWith] for a version that allows adding options.
 //
 // # Watching directories
 //
@@ -208,27 +252,41 @@ func (w *Watcher) Close() error {
 // # Watching files
 //
 // Watching individual files (rather than directories) is generally not
-// recommended as many tools update files atomically. Instead of "just" writing
-// to the file a temporary file will be written to first, and if successful the
-// temporary file is moved to to destination removing the original, or some
-// variant thereof. The watcher on the original file is now lost, as it no
-// longer exists.
+// recommended as many programs (especially editors) update files atomically: it
+// will write to a temporary file which is then moved to to destination,
+// overwriting the original (or some variant thereof). The watcher on the
+// original file is now lost, as that no longer exists.
 //
-// Instead, watch the parent directory and use Event.Name to filter out files
-// you're not interested in. There is an example of this in [cmd/fsnotify/file.go].
-func (w *Watcher) Add(name string) error {
-	w.mu.Lock()
-	if w.isClosed {
-		w.mu.Unlock()
-		return errors.New("watcher already closed")
+// The upshot of this is that a power failure or crash won't leave a
+// half-written file.
+//
+// Watch the parent directory and use Event.Name to filter out files you're not
+// interested in. There is an example of this in cmd/fsnotify/file.go.
+func (w *Watcher) Add(name string) error { return w.AddWith(name) }
+
+// AddWith is like [Watcher.Add], but allows adding options. When using Add()
+// the defaults described below are used.
+//
+// Possible options are:
+//
+//   - [WithBufferSize] sets the buffer size for the Windows backend; no-op on
+//     other platforms. The default is 64K (65536 bytes).
+func (w *Watcher) AddWith(name string, opts ...addOpt) error {
+	if w.isClosed() {
+		return ErrClosed
 	}
-	w.mu.Unlock()
+
+	with := getOptions(opts...)
+	if with.bufsize < 4096 {
+		return fmt.Errorf("fsnotify.WithBufferSize: buffer size cannot be smaller than 4096 bytes")
+	}
 
 	in := &input{
-		op:    opAddWatch,
-		path:  filepath.Clean(name),
-		flags: sysFSALLEVENTS,
-		reply: make(chan error),
+		op:      opAddWatch,
+		path:    filepath.Clean(name),
+		flags:   sysFSALLEVENTS,
+		reply:   make(chan error),
+		bufsize: with.bufsize,
 	}
 	w.input <- in
 	if err := w.wakeupReader(); err != nil {
@@ -243,7 +301,13 @@ func (w *Watcher) Add(name string) error {
 // /tmp/dir and /tmp/dir/subdir then you will need to remove both.
 //
 // Removing a path that has not yet been added returns [ErrNonExistentWatch].
+//
+// Returns nil if [Watcher.Close] was called.
 func (w *Watcher) Remove(name string) error {
+	if w.isClosed() {
+		return nil
+	}
+
 	in := &input{
 		op:    opRemoveWatch,
 		path:  filepath.Clean(name),
@@ -256,8 +320,15 @@ func (w *Watcher) Remove(name string) error {
 	return <-in.reply
 }
 
-// WatchList returns all paths added with [Add] (and are not yet removed).
+// WatchList returns all paths explicitly added with [Watcher.Add] (and are not
+// yet removed).
+//
+// Returns nil if [Watcher.Close] was called.
 func (w *Watcher) WatchList() []string {
+	if w.isClosed() {
+		return nil
+	}
+
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -279,7 +350,6 @@ func (w *Watcher) WatchList() []string {
 // This should all be removed at some point, and just use windows.FILE_NOTIFY_*
 const (
 	sysFSALLEVENTS  = 0xfff
-	sysFSATTRIB     = 0x4
 	sysFSCREATE     = 0x100
 	sysFSDELETE     = 0x200
 	sysFSDELETESELF = 0x400
@@ -305,9 +375,6 @@ func (w *Watcher) newEvent(name string, mask uint32) Event {
 	if mask&sysFSMOVE == sysFSMOVE || mask&sysFSMOVESELF == sysFSMOVESELF || mask&sysFSMOVEDFROM == sysFSMOVEDFROM {
 		e.Op |= Rename
 	}
-	if mask&sysFSATTRIB == sysFSATTRIB {
-		e.Op |= Chmod
-	}
 	return e
 }
 
@@ -321,10 +388,11 @@ const (
 )
 
 type input struct {
-	op    int
-	path  string
-	flags uint32
-	reply chan error
+	op      int
+	path    string
+	flags   uint32
+	bufsize int
+	reply   chan error
 }
 
 type inode struct {
@@ -334,13 +402,14 @@ type inode struct {
 }
 
 type watch struct {
-	ov     windows.Overlapped
-	ino    *inode            // i-number
-	path   string            // Directory path
-	mask   uint64            // Directory itself is being watched with these notify flags
-	names  map[string]uint64 // Map of names being watched and their notify flags
-	rename string            // Remembers the old name while renaming a file
-	buf    [65536]byte       // 64K buffer
+	ov      windows.Overlapped
+	ino     *inode            // i-number
+	recurse bool              // Recursive watch?
+	path    string            // Directory path
+	mask    uint64            // Directory itself is being watched with these notify flags
+	names   map[string]uint64 // Map of names being watched and their notify flags
+	rename  string            // Remembers the old name while renaming a file
+	buf     []byte            // buffer, allocated later
 }
 
 type (
@@ -413,7 +482,10 @@ func (m watchMap) set(ino *inode, watch *watch) {
 }
 
 // Must run within the I/O thread.
-func (w *Watcher) addWatch(pathname string, flags uint64) error {
+func (w *Watcher) addWatch(pathname string, flags uint64, bufsize int) error {
+	//pathname, recurse := recursivePath(pathname)
+	recurse := false
+
 	dir, err := w.getDir(pathname)
 	if err != nil {
 		return err
@@ -433,9 +505,11 @@ func (w *Watcher) addWatch(pathname string, flags uint64) error {
 			return os.NewSyscallError("CreateIoCompletionPort", err)
 		}
 		watchEntry = &watch{
-			ino:   ino,
-			path:  dir,
-			names: make(map[string]uint64),
+			ino:     ino,
+			path:    dir,
+			names:   make(map[string]uint64),
+			recurse: recurse,
+			buf:     make([]byte, bufsize),
 		}
 		w.mu.Lock()
 		w.watches.set(ino, watchEntry)
@@ -465,6 +539,8 @@ func (w *Watcher) addWatch(pathname string, flags uint64) error {
 
 // Must run within the I/O thread.
 func (w *Watcher) remWatch(pathname string) error {
+	pathname, recurse := recursivePath(pathname)
+
 	dir, err := w.getDir(pathname)
 	if err != nil {
 		return err
@@ -477,6 +553,10 @@ func (w *Watcher) remWatch(pathname string) error {
 	w.mu.Lock()
 	watch := w.watches.get(ino)
 	w.mu.Unlock()
+
+	if recurse && !watch.recurse {
+		return fmt.Errorf("can't use \\... with non-recursive watch %q", pathname)
+	}
 
 	err = windows.CloseHandle(ino.handle)
 	if err != nil {
@@ -535,8 +615,11 @@ func (w *Watcher) startRead(watch *watch) error {
 		return nil
 	}
 
-	rdErr := windows.ReadDirectoryChanges(watch.ino.handle, &watch.buf[0],
-		uint32(unsafe.Sizeof(watch.buf)), false, mask, nil, &watch.ov, 0)
+	// We need to pass the array, rather than the slice.
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&watch.buf))
+	rdErr := windows.ReadDirectoryChanges(watch.ino.handle,
+		(*byte)(unsafe.Pointer(hdr.Data)), uint32(hdr.Len),
+		watch.recurse, mask, nil, &watch.ov, 0)
 	if rdErr != nil {
 		err := os.NewSyscallError("ReadDirectoryChanges", rdErr)
 		if rdErr == windows.ERROR_ACCESS_DENIED && watch.mask&provisional == 0 {
@@ -563,9 +646,8 @@ func (w *Watcher) readEvents() {
 	runtime.LockOSThread()
 
 	for {
+		// This error is handled after the watch == nil check below.
 		qErr := windows.GetQueuedCompletionStatus(w.port, &n, &key, &ov, windows.INFINITE)
-		// This error is handled after the watch == nil check below. NOTE: this
-		// seems odd, note sure if it's correct.
 
 		watch := (*watch)(unsafe.Pointer(ov))
 		if watch == nil {
@@ -595,7 +677,7 @@ func (w *Watcher) readEvents() {
 			case in := <-w.input:
 				switch in.op {
 				case opAddWatch:
-					in.reply <- w.addWatch(in.path, uint64(in.flags))
+					in.reply <- w.addWatch(in.path, uint64(in.flags), in.bufsize)
 				case opRemoveWatch:
 					in.reply <- w.remWatch(in.path)
 				}
@@ -605,6 +687,8 @@ func (w *Watcher) readEvents() {
 		}
 
 		switch qErr {
+		case nil:
+			// No error
 		case windows.ERROR_MORE_DATA:
 			if watch == nil {
 				w.sendError(errors.New("ERROR_MORE_DATA has unexpectedly null lpOverlapped buffer"))
@@ -626,13 +710,12 @@ func (w *Watcher) readEvents() {
 		default:
 			w.sendError(os.NewSyscallError("GetQueuedCompletionPort", qErr))
 			continue
-		case nil:
 		}
 
 		var offset uint32
 		for {
 			if n == 0 {
-				w.sendError(errors.New("short read in readEvents()"))
+				w.sendError(ErrEventOverflow)
 				break
 			}
 
@@ -703,8 +786,9 @@ func (w *Watcher) readEvents() {
 
 			// Error!
 			if offset >= n {
+				//lint:ignore ST1005 Windows should be capitalized
 				w.sendError(errors.New(
-					"Windows system assumed buffer larger than it is, events have likely been missed."))
+					"Windows system assumed buffer larger than it is, events have likely been missed"))
 				break
 			}
 		}
@@ -719,9 +803,6 @@ func (w *Watcher) toWindowsFlags(mask uint64) uint32 {
 	var m uint32
 	if mask&sysFSMODIFY != 0 {
 		m |= windows.FILE_NOTIFY_CHANGE_LAST_WRITE
-	}
-	if mask&sysFSATTRIB != 0 {
-		m |= windows.FILE_NOTIFY_CHANGE_ATTRIBUTES
 	}
 	if mask&(sysFSMOVE|sysFSCREATE|sysFSDELETE) != 0 {
 		m |= windows.FILE_NOTIFY_CHANGE_FILE_NAME | windows.FILE_NOTIFY_CHANGE_DIR_NAME

--- a/vendor/github.com/fsnotify/fsnotify/fsnotify.go
+++ b/vendor/github.com/fsnotify/fsnotify/fsnotify.go
@@ -1,13 +1,18 @@
-//go:build !plan9
-// +build !plan9
-
 // Package fsnotify provides a cross-platform interface for file system
 // notifications.
+//
+// Currently supported systems:
+//
+//	Linux 2.6.32+    via inotify
+//	BSD, macOS       via kqueue
+//	Windows          via ReadDirectoryChangesW
+//	illumos          via FEN
 package fsnotify
 
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 )
 
@@ -33,34 +38,52 @@ type Op uint32
 // The operations fsnotify can trigger; see the documentation on [Watcher] for a
 // full description, and check them with [Event.Has].
 const (
+	// A new pathname was created.
 	Create Op = 1 << iota
+
+	// The pathname was written to; this does *not* mean the write has finished,
+	// and a write can be followed by more writes.
 	Write
+
+	// The path was removed; any watches on it will be removed. Some "remove"
+	// operations may trigger a Rename if the file is actually moved (for
+	// example "remove to trash" is often a rename).
 	Remove
+
+	// The path was renamed to something else; any watched on it will be
+	// removed.
 	Rename
+
+	// File attributes were changed.
+	//
+	// It's generally not recommended to take action on this event, as it may
+	// get triggered very frequently by some software. For example, Spotlight
+	// indexing on macOS, anti-virus software, backup software, etc.
 	Chmod
 )
 
-// Common errors that can be reported by a watcher
+// Common errors that can be reported.
 var (
-	ErrNonExistentWatch = errors.New("can't remove non-existent watcher")
-	ErrEventOverflow    = errors.New("fsnotify queue overflow")
+	ErrNonExistentWatch = errors.New("fsnotify: can't remove non-existent watch")
+	ErrEventOverflow    = errors.New("fsnotify: queue or buffer overflow")
+	ErrClosed           = errors.New("fsnotify: watcher already closed")
 )
 
-func (op Op) String() string {
+func (o Op) String() string {
 	var b strings.Builder
-	if op.Has(Create) {
+	if o.Has(Create) {
 		b.WriteString("|CREATE")
 	}
-	if op.Has(Remove) {
+	if o.Has(Remove) {
 		b.WriteString("|REMOVE")
 	}
-	if op.Has(Write) {
+	if o.Has(Write) {
 		b.WriteString("|WRITE")
 	}
-	if op.Has(Rename) {
+	if o.Has(Rename) {
 		b.WriteString("|RENAME")
 	}
-	if op.Has(Chmod) {
+	if o.Has(Chmod) {
 		b.WriteString("|CHMOD")
 	}
 	if b.Len() == 0 {
@@ -70,7 +93,7 @@ func (op Op) String() string {
 }
 
 // Has reports if this operation has the given operation.
-func (o Op) Has(h Op) bool { return o&h == h }
+func (o Op) Has(h Op) bool { return o&h != 0 }
 
 // Has reports if this event has the given operation.
 func (e Event) Has(op Op) bool { return e.Op.Has(op) }
@@ -78,4 +101,46 @@ func (e Event) Has(op Op) bool { return e.Op.Has(op) }
 // String returns a string representation of the event with their path.
 func (e Event) String() string {
 	return fmt.Sprintf("%-13s %q", e.Op.String(), e.Name)
+}
+
+type (
+	addOpt   func(opt *withOpts)
+	withOpts struct {
+		bufsize int
+	}
+)
+
+var defaultOpts = withOpts{
+	bufsize: 65536, // 64K
+}
+
+func getOptions(opts ...addOpt) withOpts {
+	with := defaultOpts
+	for _, o := range opts {
+		o(&with)
+	}
+	return with
+}
+
+// WithBufferSize sets the [ReadDirectoryChangesW] buffer size.
+//
+// This only has effect on Windows systems, and is a no-op for other backends.
+//
+// The default value is 64K (65536 bytes) which is the highest value that works
+// on all filesystems and should be enough for most applications, but if you
+// have a large burst of events it may not be enough. You can increase it if
+// you're hitting "queue or buffer overflow" errors ([ErrEventOverflow]).
+//
+// [ReadDirectoryChangesW]: https://learn.microsoft.com/en-gb/windows/win32/api/winbase/nf-winbase-readdirectorychangesw
+func WithBufferSize(bytes int) addOpt {
+	return func(opt *withOpts) { opt.bufsize = bytes }
+}
+
+// Check if this path is recursive (ends with "/..." or "\..."), and return the
+// path with the /... stripped.
+func recursivePath(path string) (string, bool) {
+	if filepath.Base(path) == "..." {
+		return filepath.Dir(path), true
+	}
+	return path, false
 }

--- a/vendor/github.com/fsnotify/fsnotify/mkdoc.zsh
+++ b/vendor/github.com/fsnotify/fsnotify/mkdoc.zsh
@@ -2,8 +2,8 @@
 [ "${ZSH_VERSION:-}" = "" ] && echo >&2 "Only works with zsh" && exit 1
 setopt err_exit no_unset pipefail extended_glob
 
-# Simple script to update the godoc comments on all watchers. Probably took me
-# more time to write this than doing it manually, but ah well 🙃
+# Simple script to update the godoc comments on all watchers so you don't need
+# to update the same comment 5 times.
 
 watcher=$(<<EOF
 // Watcher watches a set of paths, delivering events on a channel.
@@ -16,9 +16,9 @@ watcher=$(<<EOF
 // When a file is removed a Remove event won't be emitted until all file
 // descriptors are closed, and deletes will always emit a Chmod. For example:
 //
-//     fp := os.Open("file")
-//     os.Remove("file")        // Triggers Chmod
-//     fp.Close()               // Triggers Remove
+//	fp := os.Open("file")
+//	os.Remove("file")        // Triggers Chmod
+//	fp.Close()               // Triggers Remove
 //
 // This is the event that inotify sends, so not much can be changed about this.
 //
@@ -32,16 +32,16 @@ watcher=$(<<EOF
 //
 // To increase them you can use sysctl or write the value to the /proc file:
 //
-//     # Default values on Linux 5.18
-//     sysctl fs.inotify.max_user_watches=124983
-//     sysctl fs.inotify.max_user_instances=128
+//	# Default values on Linux 5.18
+//	sysctl fs.inotify.max_user_watches=124983
+//	sysctl fs.inotify.max_user_instances=128
 //
 // To make the changes persist on reboot edit /etc/sysctl.conf or
 // /usr/lib/sysctl.d/50-default.conf (details differ per Linux distro; check
 // your distro's documentation):
 //
-//     fs.inotify.max_user_watches=124983
-//     fs.inotify.max_user_instances=128
+//	fs.inotify.max_user_watches=124983
+//	fs.inotify.max_user_instances=128
 //
 // Reaching the limit will result in a "no space left on device" or "too many open
 // files" error.
@@ -57,14 +57,20 @@ watcher=$(<<EOF
 // control the maximum number of open files, as well as /etc/login.conf on BSD
 // systems.
 //
-// # macOS notes
+// # Windows notes
 //
-// Spotlight indexing on macOS can result in multiple events (see [#15]). A
-// temporary workaround is to add your folder(s) to the "Spotlight Privacy
-// Settings" until we have a native FSEvents implementation (see [#11]).
+// Paths can be added as "C:\\path\\to\\dir", but forward slashes
+// ("C:/path/to/dir") will also work.
 //
-// [#11]: https://github.com/fsnotify/fsnotify/issues/11
-// [#15]: https://github.com/fsnotify/fsnotify/issues/15
+// When a watched directory is removed it will always send an event for the
+// directory itself, but may not send events for all files in that directory.
+// Sometimes it will send events for all times, sometimes it will send no
+// events, and often only for some files.
+//
+// The default ReadDirectoryChangesW() buffer size is 64K, which is the largest
+// value that is guaranteed to work with SMB filesystems. If you have many
+// events in quick succession this may not be enough, and you will have to use
+// [WithBufferSize] to increase the value.
 EOF
 )
 
@@ -73,19 +79,35 @@ new=$(<<EOF
 EOF
 )
 
+newbuffered=$(<<EOF
+// NewBufferedWatcher creates a new Watcher with a buffered Watcher.Events
+// channel.
+//
+// The main use case for this is situations with a very large number of events
+// where the kernel buffer size can't be increased (e.g. due to lack of
+// permissions). An unbuffered Watcher will perform better for almost all use
+// cases, and whenever possible you will be better off increasing the kernel
+// buffers instead of adding a large userspace buffer.
+EOF
+)
+
 add=$(<<EOF
 // Add starts monitoring the path for changes.
 //
-// A path can only be watched once; attempting to watch it more than once will
-// return an error. Paths that do not yet exist on the filesystem cannot be
-// added. A watch will be automatically removed if the path is deleted.
+// A path can only be watched once; watching it more than once is a no-op and will
+// not return an error. Paths that do not yet exist on the filesystem cannot be
+// watched.
 //
-// A path will remain watched if it gets renamed to somewhere else on the same
-// filesystem, but the monitor will get removed if the path gets deleted and
-// re-created, or if it's moved to a different filesystem.
+// A watch will be automatically removed if the watched path is deleted or
+// renamed. The exception is the Windows backend, which doesn't remove the
+// watcher on renames.
 //
 // Notifications on network filesystems (NFS, SMB, FUSE, etc.) or special
 // filesystems (/proc, /sys, etc.) generally don't work.
+//
+// Returns [ErrClosed] if [Watcher.Close] was called.
+//
+// See [Watcher.AddWith] for a version that allows adding options.
 //
 // # Watching directories
 //
@@ -96,14 +118,27 @@ add=$(<<EOF
 // # Watching files
 //
 // Watching individual files (rather than directories) is generally not
-// recommended as many tools update files atomically. Instead of "just" writing
-// to the file a temporary file will be written to first, and if successful the
-// temporary file is moved to to destination removing the original, or some
-// variant thereof. The watcher on the original file is now lost, as it no
-// longer exists.
+// recommended as many programs (especially editors) update files atomically: it
+// will write to a temporary file which is then moved to to destination,
+// overwriting the original (or some variant thereof). The watcher on the
+// original file is now lost, as that no longer exists.
 //
-// Instead, watch the parent directory and use Event.Name to filter out files
-// you're not interested in. There is an example of this in [cmd/fsnotify/file.go].
+// The upshot of this is that a power failure or crash won't leave a
+// half-written file.
+//
+// Watch the parent directory and use Event.Name to filter out files you're not
+// interested in. There is an example of this in cmd/fsnotify/file.go.
+EOF
+)
+
+addwith=$(<<EOF
+// AddWith is like [Watcher.Add], but allows adding options. When using Add()
+// the defaults described below are used.
+//
+// Possible options are:
+//
+//   - [WithBufferSize] sets the buffer size for the Windows backend; no-op on
+//     other platforms. The default is 64K (65536 bytes).
 EOF
 )
 
@@ -114,16 +149,21 @@ remove=$(<<EOF
 // /tmp/dir and /tmp/dir/subdir then you will need to remove both.
 //
 // Removing a path that has not yet been added returns [ErrNonExistentWatch].
+//
+// Returns nil if [Watcher.Close] was called.
 EOF
 )
 
 close=$(<<EOF
-// Close removes all watches and closes the events channel.
+// Close removes all watches and closes the Events channel.
 EOF
 )
 
 watchlist=$(<<EOF
-// WatchList returns all paths added with [Add] (and are not yet removed).
+// WatchList returns all paths explicitly added with [Watcher.Add] (and are not
+// yet removed).
+//
+// Returns nil if [Watcher.Close] was called.
 EOF
 )
 
@@ -153,20 +193,29 @@ events=$(<<EOF
 	//                      initiated by the user may show up as one or multiple
 	//                      writes, depending on when the system syncs things to
 	//                      disk. For example when compiling a large Go program
-	//                      you may get hundreds of Write events, so you
-	//                      probably want to wait until you've stopped receiving
-	//                      them (see the dedup example in cmd/fsnotify).
+	//                      you may get hundreds of Write events, and you may
+	//                      want to wait until you've stopped receiving them
+	//                      (see the dedup example in cmd/fsnotify).
+	//
+	//                      Some systems may send Write event for directories
+	//                      when the directory content changes.
 	//
 	//   fsnotify.Chmod     Attributes were changed. On Linux this is also sent
 	//                      when a file is removed (or more accurately, when a
 	//                      link to an inode is removed). On kqueue it's sent
-	//                      and on kqueue when a file is truncated. On Windows
-	//                      it's never sent.
+	//                      when a file is truncated. On Windows it's never
+	//                      sent.
 EOF
 )
 
 errors=$(<<EOF
 	// Errors sends any errors.
+	//
+	// ErrEventOverflow is used to indicate there are too many events:
+	//
+	//  - inotify:      There are too many queued events (fs.inotify.max_queued_events sysctl)
+	//  - windows:      The buffer size is too small; WithBufferSize() can be used to increase it.
+	//  - kqueue, fen:  Not used.
 EOF
 )
 
@@ -200,7 +249,9 @@ set-cmt() {
 
 set-cmt '^type Watcher struct '             $watcher
 set-cmt '^func NewWatcher('                 $new
+set-cmt '^func NewBufferedWatcher('         $newbuffered
 set-cmt '^func (w \*Watcher) Add('          $add
+set-cmt '^func (w \*Watcher) AddWith('      $addwith
 set-cmt '^func (w \*Watcher) Remove('       $remove
 set-cmt '^func (w \*Watcher) Close('        $close
 set-cmt '^func (w \*Watcher) WatchList('    $watchlist

--- a/vendor/github.com/prometheus/common/config/http_config.go
+++ b/vendor/github.com/prometheus/common/config/http_config.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -29,6 +30,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/mwitkow/go-conntrack"
 	"golang.org/x/net/http/httpproxy"
@@ -130,8 +132,10 @@ func (tv *TLSVersion) String() string {
 type BasicAuth struct {
 	Username     string `yaml:"username" json:"username"`
 	UsernameFile string `yaml:"username_file,omitempty" json:"username_file,omitempty"`
+	UsernameRef  string `yaml:"username_ref,omitempty" json:"username_ref,omitempty"`
 	Password     Secret `yaml:"password,omitempty" json:"password,omitempty"`
 	PasswordFile string `yaml:"password_file,omitempty" json:"password_file,omitempty"`
+	PasswordRef  string `yaml:"password_ref,omitempty" json:"password_ref,omitempty"`
 }
 
 // SetDirectory joins any relative file paths with dir.
@@ -148,6 +152,7 @@ type Authorization struct {
 	Type            string `yaml:"type,omitempty" json:"type,omitempty"`
 	Credentials     Secret `yaml:"credentials,omitempty" json:"credentials,omitempty"`
 	CredentialsFile string `yaml:"credentials_file,omitempty" json:"credentials_file,omitempty"`
+	CredentialsRef  string `yaml:"credentials_ref,omitempty" json:"credentials_ref,omitempty"`
 }
 
 // SetDirectory joins any relative file paths with dir.
@@ -227,6 +232,7 @@ type OAuth2 struct {
 	ClientID         string            `yaml:"client_id" json:"client_id"`
 	ClientSecret     Secret            `yaml:"client_secret" json:"client_secret"`
 	ClientSecretFile string            `yaml:"client_secret_file" json:"client_secret_file"`
+	ClientSecretRef  string            `yaml:"client_secret_ref" json:"client_secret_ref"`
 	Scopes           []string          `yaml:"scopes,omitempty" json:"scopes,omitempty"`
 	TokenURL         string            `yaml:"token_url" json:"token_url"`
 	EndpointParams   map[string]string `yaml:"endpoint_params,omitempty" json:"endpoint_params,omitempty"`
@@ -325,6 +331,15 @@ func (c *HTTPClientConfig) SetDirectory(dir string) {
 	c.BearerTokenFile = JoinDir(dir, c.BearerTokenFile)
 }
 
+// atLeastTwoTrue returns true if at least any of the two of three given bools
+// are true.
+func atLeastTwoTrue(a, b, c bool) bool {
+	if a == b {
+		return a
+	}
+	return c
+}
+
 // Validate validates the HTTPClientConfig to check only one of BearerToken,
 // BasicAuth and BearerTokenFile is configured. It also validates that ProxyURL
 // is set if ProxyConnectHeader is set.
@@ -336,17 +351,17 @@ func (c *HTTPClientConfig) Validate() error {
 	if (c.BasicAuth != nil || c.OAuth2 != nil) && (len(c.BearerToken) > 0 || len(c.BearerTokenFile) > 0) {
 		return fmt.Errorf("at most one of basic_auth, oauth2, bearer_token & bearer_token_file must be configured")
 	}
-	if c.BasicAuth != nil && (string(c.BasicAuth.Username) != "" && c.BasicAuth.UsernameFile != "") {
-		return fmt.Errorf("at most one of basic_auth username & username_file must be configured")
+	if c.BasicAuth != nil && atLeastTwoTrue(string(c.BasicAuth.Username) != "", c.BasicAuth.UsernameFile != "", c.BasicAuth.UsernameRef != "") {
+		return fmt.Errorf("at most one of basic_auth username, username_file & username_ref must be configured")
 	}
-	if c.BasicAuth != nil && (string(c.BasicAuth.Password) != "" && c.BasicAuth.PasswordFile != "") {
-		return fmt.Errorf("at most one of basic_auth password & password_file must be configured")
+	if c.BasicAuth != nil && atLeastTwoTrue(string(c.BasicAuth.Password) != "", c.BasicAuth.PasswordFile != "", c.BasicAuth.PasswordRef != "") {
+		return fmt.Errorf("at most one of basic_auth password, password_file & password_ref must be configured")
 	}
 	if c.Authorization != nil {
 		if len(c.BearerToken) > 0 || len(c.BearerTokenFile) > 0 {
 			return fmt.Errorf("authorization is not compatible with bearer_token & bearer_token_file")
 		}
-		if string(c.Authorization.Credentials) != "" && c.Authorization.CredentialsFile != "" {
+		if atLeastTwoTrue(string(c.Authorization.Credentials) != "", c.Authorization.CredentialsFile != "", c.Authorization.CredentialsRef != "") {
 			return fmt.Errorf("at most one of authorization credentials & credentials_file must be configured")
 		}
 		c.Authorization.Type = strings.TrimSpace(c.Authorization.Type)
@@ -381,8 +396,8 @@ func (c *HTTPClientConfig) Validate() error {
 		if len(c.OAuth2.TokenURL) == 0 {
 			return fmt.Errorf("oauth2 token_url must be configured")
 		}
-		if len(c.OAuth2.ClientSecret) > 0 && len(c.OAuth2.ClientSecretFile) > 0 {
-			return fmt.Errorf("at most one of oauth2 client_secret & client_secret_file must be configured")
+		if atLeastTwoTrue(len(c.OAuth2.ClientSecret) > 0, len(c.OAuth2.ClientSecretFile) > 0, len(c.OAuth2.ClientSecretRef) > 0) {
+			return fmt.Errorf("at most one of oauth2 client_secret, client_secret_file & client_secret_ref must be configured")
 		}
 	}
 	if err := c.ProxyConfig.Validate(); err != nil {
@@ -427,6 +442,7 @@ type httpClientOptions struct {
 	http2Enabled      bool
 	idleConnTimeout   time.Duration
 	userAgent         string
+	secretManager     SecretManager
 }
 
 // HTTPClientOption defines an option that can be applied to the HTTP client.
@@ -467,6 +483,13 @@ func WithUserAgent(ua string) HTTPClientOption {
 	}
 }
 
+// WithSecretManager allows setting the secret manager.
+func WithSecretManager(manager SecretManager) HTTPClientOption {
+	return func(opts *httpClientOptions) {
+		opts.secretManager = manager
+	}
+}
+
 // NewClient returns a http.Client using the specified http.RoundTripper.
 func newClient(rt http.RoundTripper) *http.Client {
 	return &http.Client{Transport: rt}
@@ -493,6 +516,13 @@ func NewClientFromConfig(cfg HTTPClientConfig, name string, optFuncs ...HTTPClie
 // given config.HTTPClientConfig and config.HTTPClientOption.
 // The name is used as go-conntrack metric label.
 func NewRoundTripperFromConfig(cfg HTTPClientConfig, name string, optFuncs ...HTTPClientOption) (http.RoundTripper, error) {
+	return NewRoundTripperFromConfigWithContext(context.Background(), cfg, name, optFuncs...)
+}
+
+// NewRoundTripperFromConfig returns a new HTTP RoundTripper configured for the
+// given config.HTTPClientConfig and config.HTTPClientOption.
+// The name is used as go-conntrack metric label.
+func NewRoundTripperFromConfigWithContext(ctx context.Context, cfg HTTPClientConfig, name string, optFuncs ...HTTPClientOption) (http.RoundTripper, error) {
 	opts := defaultHTTPClientOptions
 	for _, f := range optFuncs {
 		f(&opts)
@@ -543,21 +573,33 @@ func NewRoundTripperFromConfig(cfg HTTPClientConfig, name string, optFuncs ...HT
 
 		// If a authorization_credentials is provided, create a round tripper that will set the
 		// Authorization header correctly on each request.
-		if cfg.Authorization != nil && len(cfg.Authorization.CredentialsFile) > 0 {
-			rt = NewAuthorizationCredentialsFileRoundTripper(cfg.Authorization.Type, cfg.Authorization.CredentialsFile, rt)
-		} else if cfg.Authorization != nil {
-			rt = NewAuthorizationCredentialsRoundTripper(cfg.Authorization.Type, cfg.Authorization.Credentials, rt)
+		if cfg.Authorization != nil {
+			credentialsSecret, err := secretFrom(opts.secretManager, cfg.Authorization.Credentials, cfg.Authorization.CredentialsFile, cfg.Authorization.CredentialsRef)
+			if err != nil {
+				return nil, fmt.Errorf("unable to use credentials: %w", err)
+			}
+			rt = NewAuthorizationCredentialsRoundTripper(cfg.Authorization.Type, credentialsSecret, rt)
 		}
 		// Backwards compatibility, be nice with importers who would not have
 		// called Validate().
-		if len(cfg.BearerToken) > 0 {
-			rt = NewAuthorizationCredentialsRoundTripper("Bearer", cfg.BearerToken, rt)
-		} else if len(cfg.BearerTokenFile) > 0 {
-			rt = NewAuthorizationCredentialsFileRoundTripper("Bearer", cfg.BearerTokenFile, rt)
+		if len(cfg.BearerToken) > 0 || len(cfg.BearerTokenFile) > 0 {
+			bearerSecret, err := secretFrom(opts.secretManager, cfg.BearerToken, cfg.BearerTokenFile, "")
+			if err != nil {
+				return nil, fmt.Errorf("unable to use bearer token: %w", err)
+			}
+			rt = NewAuthorizationCredentialsRoundTripper("Bearer", bearerSecret, rt)
 		}
 
 		if cfg.BasicAuth != nil {
-			rt = NewBasicAuthRoundTripper(cfg.BasicAuth.Username, cfg.BasicAuth.Password, cfg.BasicAuth.UsernameFile, cfg.BasicAuth.PasswordFile, rt)
+			usernameSecret, err := secretFrom(opts.secretManager, Secret(cfg.BasicAuth.Username), cfg.BasicAuth.UsernameFile, cfg.BasicAuth.UsernameRef)
+			if err != nil {
+				return nil, fmt.Errorf("unable to use username: %w", err)
+			}
+			passwordSecret, err := secretFrom(opts.secretManager, cfg.BasicAuth.Password, cfg.BasicAuth.PasswordFile, cfg.BasicAuth.PasswordRef)
+			if err != nil {
+				return nil, fmt.Errorf("unable to use password: %w", err)
+			}
+			rt = NewBasicAuthRoundTripper(usernameSecret, passwordSecret, rt)
 		}
 
 		if cfg.OAuth2 != nil {
@@ -572,35 +614,136 @@ func NewRoundTripperFromConfig(cfg HTTPClientConfig, name string, optFuncs ...HT
 		return rt, nil
 	}
 
-	tlsConfig, err := NewTLSConfig(&cfg.TLSConfig)
+	tlsConfig, err := NewTLSConfig(&cfg.TLSConfig, withSecretManager(opts.secretManager))
 	if err != nil {
 		return nil, err
 	}
 
-	if len(cfg.TLSConfig.CAFile) == 0 {
+	tlsSettings, err := cfg.TLSConfig.roundTripperSettings(opts.secretManager)
+	if err != nil {
+		return nil, err
+	}
+	if tlsSettings.CA == nil || tlsSettings.CA.immutable() {
 		// No need for a RoundTripper that reloads the CA file automatically.
 		return newRT(tlsConfig)
 	}
-	return NewTLSRoundTripper(tlsConfig, cfg.TLSConfig.roundTripperSettings(), newRT)
+	return NewTLSRoundTripperWithContext(ctx, tlsConfig, tlsSettings, newRT)
+}
+
+type SecretManager interface {
+	Fetch(ctx context.Context, secretRef string) (string, error)
+}
+
+type secret interface {
+	fetch(ctx context.Context) (string, error)
+	description() string
+	immutable() bool
+}
+
+type inlineSecret struct {
+	text string
+}
+
+func (s *inlineSecret) fetch(ctx context.Context) (string, error) {
+	return s.text, nil
+}
+
+func (s *inlineSecret) description() string {
+	return "inline"
+}
+
+func (s *inlineSecret) immutable() bool {
+	return true
+}
+
+type fileSecret struct {
+	file string
+}
+
+func (s *fileSecret) fetch(ctx context.Context) (string, error) {
+	fileBytes, err := os.ReadFile(s.file)
+	if err != nil {
+		return "", fmt.Errorf("unable to read file %s: %w", s.file, err)
+	}
+	return strings.TrimSpace(string(fileBytes)), nil
+}
+
+func (s *fileSecret) description() string {
+	return fmt.Sprintf("file %s", s.file)
+}
+
+func (s *fileSecret) immutable() bool {
+	return false
+}
+
+type refSecret struct {
+	ref     string
+	manager SecretManager
+}
+
+func (s *refSecret) fetch(ctx context.Context) (string, error) {
+	return s.manager.Fetch(ctx, s.ref)
+}
+
+func (s *refSecret) description() string {
+	return fmt.Sprintf("ref %s", s.ref)
+}
+
+func (s *refSecret) immutable() bool {
+	return false
+}
+
+func secretFrom(secretManager SecretManager, text Secret, file, ref string) (secret, error) {
+	if text != "" {
+		return &inlineSecret{
+			text: string(text),
+		}, nil
+	}
+	if file != "" {
+		return &fileSecret{
+			file: file,
+		}, nil
+	}
+	if ref != "" {
+		if secretManager == nil {
+			return nil, errors.New("cannot use secret ref without manager")
+		}
+		return &refSecret{
+			ref:     ref,
+			manager: secretManager,
+		}, nil
+	}
+	return nil, nil
 }
 
 type authorizationCredentialsRoundTripper struct {
 	authType        string
-	authCredentials Secret
+	authCredentials secret
 	rt              http.RoundTripper
 }
 
-// NewAuthorizationCredentialsRoundTripper adds the provided credentials to a
-// request unless the authorization header has already been set.
-func NewAuthorizationCredentialsRoundTripper(authType string, authCredentials Secret, rt http.RoundTripper) http.RoundTripper {
+// NewAuthorizationCredentialsRoundTripper adds the authorization credentials
+// read from the provided secret to a request unless the authorization header
+// has already been set.
+func NewAuthorizationCredentialsRoundTripper(authType string, authCredentials secret, rt http.RoundTripper) http.RoundTripper {
 	return &authorizationCredentialsRoundTripper{authType, authCredentials, rt}
 }
 
 func (rt *authorizationCredentialsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if len(req.Header.Get("Authorization")) == 0 {
+		var authCredentials string
+		if rt.authCredentials != nil {
+			var err error
+			authCredentials, err = rt.authCredentials.fetch(req.Context())
+			if err != nil {
+				return nil, fmt.Errorf("unable to read authorization credentials: %w", err)
+			}
+		}
+
 		req = cloneRequest(req)
-		req.Header.Set("Authorization", fmt.Sprintf("%s %s", rt.authType, string(rt.authCredentials)))
+		req.Header.Set("Authorization", fmt.Sprintf("%s %s", rt.authType, authCredentials))
 	}
+
 	return rt.rt.RoundTrip(req)
 }
 
@@ -610,77 +753,37 @@ func (rt *authorizationCredentialsRoundTripper) CloseIdleConnections() {
 	}
 }
 
-type authorizationCredentialsFileRoundTripper struct {
-	authType            string
-	authCredentialsFile string
-	rt                  http.RoundTripper
-}
-
-// NewAuthorizationCredentialsFileRoundTripper adds the authorization
-// credentials read from the provided file to a request unless the authorization
-// header has already been set. This file is read for every request.
-func NewAuthorizationCredentialsFileRoundTripper(authType, authCredentialsFile string, rt http.RoundTripper) http.RoundTripper {
-	return &authorizationCredentialsFileRoundTripper{authType, authCredentialsFile, rt}
-}
-
-func (rt *authorizationCredentialsFileRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	if len(req.Header.Get("Authorization")) == 0 {
-		b, err := os.ReadFile(rt.authCredentialsFile)
-		if err != nil {
-			return nil, fmt.Errorf("unable to read authorization credentials file %s: %s", rt.authCredentialsFile, err)
-		}
-		authCredentials := strings.TrimSpace(string(b))
-
-		req = cloneRequest(req)
-		req.Header.Set("Authorization", fmt.Sprintf("%s %s", rt.authType, authCredentials))
-	}
-
-	return rt.rt.RoundTrip(req)
-}
-
-func (rt *authorizationCredentialsFileRoundTripper) CloseIdleConnections() {
-	if ci, ok := rt.rt.(closeIdler); ok {
-		ci.CloseIdleConnections()
-	}
-}
-
 type basicAuthRoundTripper struct {
-	username     string
-	password     Secret
-	usernameFile string
-	passwordFile string
-	rt           http.RoundTripper
+	username secret
+	password secret
+	rt       http.RoundTripper
 }
 
 // NewBasicAuthRoundTripper will apply a BASIC auth authorization header to a request unless it has
 // already been set.
-func NewBasicAuthRoundTripper(username string, password Secret, usernameFile, passwordFile string, rt http.RoundTripper) http.RoundTripper {
-	return &basicAuthRoundTripper{username, password, usernameFile, passwordFile, rt}
+func NewBasicAuthRoundTripper(username secret, password secret, rt http.RoundTripper) http.RoundTripper {
+	return &basicAuthRoundTripper{username, password, rt}
 }
 
 func (rt *basicAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	var username string
-	var password string
 	if len(req.Header.Get("Authorization")) != 0 {
 		return rt.rt.RoundTrip(req)
 	}
-	if rt.usernameFile != "" {
-		usernameBytes, err := os.ReadFile(rt.usernameFile)
+	var username string
+	var password string
+	if rt.username != nil {
+		var err error
+		username, err = rt.username.fetch(req.Context())
 		if err != nil {
-			return nil, fmt.Errorf("unable to read basic auth username file %s: %s", rt.usernameFile, err)
+			return nil, fmt.Errorf("unable to read basic auth username: %w", err)
 		}
-		username = strings.TrimSpace(string(usernameBytes))
-	} else {
-		username = rt.username
 	}
-	if rt.passwordFile != "" {
-		passwordBytes, err := os.ReadFile(rt.passwordFile)
+	if rt.password != nil {
+		var err error
+		password, err = rt.password.fetch(req.Context())
 		if err != nil {
-			return nil, fmt.Errorf("unable to read basic auth password file %s: %s", rt.passwordFile, err)
+			return nil, fmt.Errorf("unable to read basic auth password: %w", err)
 		}
-		password = strings.TrimSpace(string(passwordBytes))
-	} else {
-		password = string(rt.password)
 	}
 	req = cloneRequest(req)
 	req.SetBasicAuth(username, password)
@@ -717,19 +820,20 @@ func (rt *oauth2RoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 		changed bool
 	)
 
-	if rt.config.ClientSecretFile != "" {
-		data, err := os.ReadFile(rt.config.ClientSecretFile)
-		if err != nil {
-			return nil, fmt.Errorf("unable to read oauth2 client secret file %s: %s", rt.config.ClientSecretFile, err)
-		}
-		secret = strings.TrimSpace(string(data))
-		rt.mtx.RLock()
-		changed = secret != rt.secret
-		rt.mtx.RUnlock()
-	} else {
-		// Either an inline secret or nothing (use an empty string) was provided.
-		secret = string(rt.config.ClientSecret)
+	clientSecret, err := secretFrom(rt.opts.secretManager, rt.config.ClientSecret, rt.config.ClientSecretFile, rt.config.ClientSecretRef)
+	if err != nil {
+		return nil, fmt.Errorf("unable to use client secret: %w", err)
 	}
+	if clientSecret != nil {
+		var err error
+		secret, err = clientSecret.fetch(req.Context())
+		if err != nil {
+			return nil, fmt.Errorf("unable to read oauth2 client secret: %w", err)
+		}
+	}
+	rt.mtx.RLock()
+	changed = secret != rt.secret
+	rt.mtx.RUnlock()
 
 	if changed || rt.rt == nil {
 		config := &clientcredentials.Config{
@@ -740,7 +844,7 @@ func (rt *oauth2RoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 			EndpointParams: mapToValues(rt.config.EndpointParams),
 		}
 
-		tlsConfig, err := NewTLSConfig(&rt.config.TLSConfig)
+		tlsConfig, err := NewTLSConfig(&rt.config.TLSConfig, withSecretManager(rt.opts.secretManager))
 		if err != nil {
 			return nil, err
 		}
@@ -760,10 +864,14 @@ func (rt *oauth2RoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 		}
 
 		var t http.RoundTripper
-		if len(rt.config.TLSConfig.CAFile) == 0 {
+		tlsSettings, err := rt.config.TLSConfig.roundTripperSettings(rt.opts.secretManager)
+		if err != nil {
+			return nil, err
+		}
+		if tlsSettings.CA == nil || tlsSettings.CA.immutable() {
 			t, _ = tlsTransport(tlsConfig)
 		} else {
-			t, err = NewTLSRoundTripper(tlsConfig, rt.config.TLSConfig.roundTripperSettings(), tlsTransport)
+			t, err = NewTLSRoundTripperWithContext(req.Context(), tlsConfig, tlsSettings, tlsTransport)
 			if err != nil {
 				return nil, err
 			}
@@ -828,8 +936,32 @@ func cloneRequest(r *http.Request) *http.Request {
 	return r2
 }
 
+type tlsConfigOptions struct {
+	secretManager SecretManager
+}
+
+// TLSConfigOption defines an option that can be applied to the HTTP client.
+type TLSConfigOption func(options *tlsConfigOptions)
+
+// WithSecretManager allows setting the secret manager.
+func withSecretManager(manager SecretManager) TLSConfigOption {
+	return func(opts *tlsConfigOptions) {
+		opts.secretManager = manager
+	}
+}
+
 // NewTLSConfig creates a new tls.Config from the given TLSConfig.
-func NewTLSConfig(cfg *TLSConfig) (*tls.Config, error) {
+func NewTLSConfig(cfg *TLSConfig, optFuncs ...TLSConfigOption) (*tls.Config, error) {
+	return NewTLSConfigWithContext(context.Background(), cfg, optFuncs...)
+}
+
+// NewTLSConfig creates a new tls.Config from the given TLSConfig.
+func NewTLSConfigWithContext(ctx context.Context, cfg *TLSConfig, optFuncs ...TLSConfigOption) (*tls.Config, error) {
+	opts := tlsConfigOptions{}
+	for _, f := range optFuncs {
+		f(&opts)
+	}
+
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
@@ -848,17 +980,17 @@ func NewTLSConfig(cfg *TLSConfig) (*tls.Config, error) {
 
 	// If a CA cert is provided then let's read it in so we can validate the
 	// scrape target's certificate properly.
-	if len(cfg.CA) > 0 {
-		if !updateRootCA(tlsConfig, []byte(cfg.CA)) {
-			return nil, fmt.Errorf("unable to use inline CA cert")
-		}
-	} else if len(cfg.CAFile) > 0 {
-		b, err := readCAFile(cfg.CAFile)
+	caSecret, err := secretFrom(opts.secretManager, Secret(cfg.CA), cfg.CAFile, cfg.CARef)
+	if err != nil {
+		return nil, fmt.Errorf("unable to use CA cert: %w", err)
+	}
+	if caSecret != nil {
+		ca, err := caSecret.fetch(ctx)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to read CA cert: %w", err)
 		}
-		if !updateRootCA(tlsConfig, b) {
-			return nil, fmt.Errorf("unable to use specified CA cert %s", cfg.CAFile)
+		if !updateRootCA(tlsConfig, []byte(ca)) {
+			return nil, fmt.Errorf("unable to use specified CA cert %s", caSecret.description())
 		}
 	}
 
@@ -869,10 +1001,16 @@ func NewTLSConfig(cfg *TLSConfig) (*tls.Config, error) {
 	// If a client cert & key is provided then configure TLS config accordingly.
 	if cfg.usingClientCert() && cfg.usingClientKey() {
 		// Verify that client cert and key are valid.
-		if _, err := cfg.getClientCertificate(nil); err != nil {
+		if _, err := cfg.getClientCertificate(ctx, opts.secretManager); err != nil {
 			return nil, err
 		}
-		tlsConfig.GetClientCertificate = cfg.getClientCertificate
+		tlsConfig.GetClientCertificate = func(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			var ctx context.Context
+			if cri != nil {
+				ctx = cri.Context()
+			}
+			return cfg.getClientCertificate(ctx, opts.secretManager)
+		}
 	}
 
 	return tlsConfig, nil
@@ -892,6 +1030,12 @@ type TLSConfig struct {
 	CertFile string `yaml:"cert_file,omitempty" json:"cert_file,omitempty"`
 	// The client key file for the targets.
 	KeyFile string `yaml:"key_file,omitempty" json:"key_file,omitempty"`
+	// The CA cert to use for the targets.
+	CARef string `yaml:"ca_ref,omitempty" json:"ca_ref,omitempty"`
+	// The client cert for the targets.
+	CertRef string `yaml:"cert_ref,omitempty" json:"cert_ref,omitempty"`
+	// The client key for the targets.
+	KeyRef string `yaml:"key_ref,omitempty" json:"key_ref,omitempty"`
 	// Used to verify the hostname for the targets.
 	ServerName string `yaml:"server_name,omitempty" json:"server_name,omitempty"`
 	// Disable target certificate validation.
@@ -925,13 +1069,13 @@ func (c *TLSConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // file-based fields for the TLS CA, client certificate, and client key are
 // used.
 func (c *TLSConfig) Validate() error {
-	if len(c.CA) > 0 && len(c.CAFile) > 0 {
-		return fmt.Errorf("at most one of ca and ca_file must be configured")
+	if atLeastTwoTrue(len(c.CA) > 0, len(c.CAFile) > 0, len(c.CARef) > 0) {
+		return fmt.Errorf("at most one of ca, ca_file & ca_ref must be configured")
 	}
-	if len(c.Cert) > 0 && len(c.CertFile) > 0 {
-		return fmt.Errorf("at most one of cert and cert_file must be configured")
+	if atLeastTwoTrue(len(c.Cert) > 0, len(c.CertFile) > 0, len(c.CertRef) > 0) {
+		return fmt.Errorf("at most one of cert, cert_file & cert_ref must be configured")
 	}
-	if len(c.Key) > 0 && len(c.KeyFile) > 0 {
+	if atLeastTwoTrue(len(c.Key) > 0, len(c.KeyFile) > 0, len(c.KeyRef) > 0) {
 		return fmt.Errorf("at most one of key and key_file must be configured")
 	}
 
@@ -945,64 +1089,70 @@ func (c *TLSConfig) Validate() error {
 }
 
 func (c *TLSConfig) usingClientCert() bool {
-	return len(c.Cert) > 0 || len(c.CertFile) > 0
+	return len(c.Cert) > 0 || len(c.CertFile) > 0 || len(c.CARef) > 0
 }
 
 func (c *TLSConfig) usingClientKey() bool {
-	return len(c.Key) > 0 || len(c.KeyFile) > 0
+	return len(c.Key) > 0 || len(c.KeyFile) > 0 || len(c.CARef) > 0
 }
 
-func (c *TLSConfig) roundTripperSettings() TLSRoundTripperSettings {
-	return TLSRoundTripperSettings{
-		CA:       c.CA,
-		CAFile:   c.CAFile,
-		Cert:     c.Cert,
-		CertFile: c.CertFile,
-		Key:      string(c.Key),
-		KeyFile:  c.KeyFile,
+func (c *TLSConfig) roundTripperSettings(secretManager SecretManager) (TLSRoundTripperSettings, error) {
+	ca, err := secretFrom(secretManager, Secret(c.CA), c.CAFile, c.CARef)
+	if err != nil {
+		return TLSRoundTripperSettings{}, err
 	}
+	cert, err := secretFrom(secretManager, Secret(c.Cert), c.CertFile, c.CertRef)
+	if err != nil {
+		return TLSRoundTripperSettings{}, err
+	}
+	key, err := secretFrom(secretManager, c.Key, c.KeyFile, c.KeyRef)
+	if err != nil {
+		return TLSRoundTripperSettings{}, err
+	}
+	return TLSRoundTripperSettings{
+		CA:   ca,
+		Cert: cert,
+		Key:  key,
+	}, nil
 }
 
 // getClientCertificate reads the pair of client cert and key from disk and returns a tls.Certificate.
-func (c *TLSConfig) getClientCertificate(_ *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+func (c *TLSConfig) getClientCertificate(ctx context.Context, secretManager SecretManager) (*tls.Certificate, error) {
 	var (
-		certData, keyData []byte
+		certData, keyData string
 		err               error
 	)
 
-	if c.CertFile != "" {
-		certData, err = os.ReadFile(c.CertFile)
-		if err != nil {
-			return nil, fmt.Errorf("unable to read specified client cert (%s): %s", c.CertFile, err)
-		}
-	} else {
-		certData = []byte(c.Cert)
-	}
-
-	if c.KeyFile != "" {
-		keyData, err = os.ReadFile(c.KeyFile)
-		if err != nil {
-			return nil, fmt.Errorf("unable to read specified client key (%s): %s", c.KeyFile, err)
-		}
-	} else {
-		keyData = []byte(c.Key)
-	}
-
-	cert, err := tls.X509KeyPair(certData, keyData)
+	certSecret, err := secretFrom(secretManager, Secret(c.Cert), c.CertFile, c.CertRef)
 	if err != nil {
-		return nil, fmt.Errorf("unable to use specified client cert (%s) & key (%s): %s", c.CertFile, c.KeyFile, err)
+		return nil, fmt.Errorf("unable to use client cert: %w", err)
+	}
+	if certSecret != nil {
+		certData, err = certSecret.fetch(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read specified client cert: %w", err)
+		}
+	}
+
+	keySecret, err := secretFrom(secretManager, Secret(c.Key), c.KeyFile, c.KeyRef)
+	if err != nil {
+		return nil, fmt.Errorf("unable to use client key: %w", err)
+	}
+	if keySecret != nil {
+		keyData, err = keySecret.fetch(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read specified client key: %w", err)
+		}
+	}
+
+	certStr := unsafe.Slice(unsafe.StringData(certData), len(certData))
+	keyStr := unsafe.Slice(unsafe.StringData(keyData), len(keyData))
+	cert, err := tls.X509KeyPair(certStr, keyStr)
+	if err != nil {
+		return nil, fmt.Errorf("unable to use specified client cert (%s) & key (%s): %w", certSecret.description(), keySecret.description(), err)
 	}
 
 	return &cert, nil
-}
-
-// readCAFile reads the CA cert file from disk.
-func readCAFile(f string) ([]byte, error) {
-	data, err := os.ReadFile(f)
-	if err != nil {
-		return nil, fmt.Errorf("unable to load specified CA cert %s: %s", f, err)
-	}
-	return data, nil
 }
 
 // updateRootCA parses the given byte slice as a series of PEM encoded certificates and updates tls.Config.RootCAs.
@@ -1032,12 +1182,21 @@ type tlsRoundTripper struct {
 }
 
 type TLSRoundTripperSettings struct {
-	CA, CAFile     string
-	Cert, CertFile string
-	Key, KeyFile   string
+	CA   secret
+	Cert secret
+	Key  secret
 }
 
 func NewTLSRoundTripper(
+	cfg *tls.Config,
+	settings TLSRoundTripperSettings,
+	newRT func(*tls.Config) (http.RoundTripper, error),
+) (http.RoundTripper, error) {
+	return NewTLSRoundTripperWithContext(context.Background(), cfg, settings, newRT)
+}
+
+func NewTLSRoundTripperWithContext(
+	ctx context.Context,
 	cfg *tls.Config,
 	settings TLSRoundTripperSettings,
 	newRT func(*tls.Config) (http.RoundTripper, error),
@@ -1053,7 +1212,7 @@ func NewTLSRoundTripper(
 		return nil, err
 	}
 	t.rt = rt
-	_, t.hashCAData, t.hashCertData, t.hashKeyData, err = t.getTLSDataWithHash()
+	_, t.hashCAData, t.hashCertData, t.hashKeyData, err = t.getTLSDataWithHash(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1061,38 +1220,33 @@ func NewTLSRoundTripper(
 	return t, nil
 }
 
-func (t *tlsRoundTripper) getTLSDataWithHash() ([]byte, []byte, []byte, []byte, error) {
+func (t *tlsRoundTripper) getTLSDataWithHash(ctx context.Context) ([]byte, []byte, []byte, []byte, error) {
 	var (
 		caBytes, certBytes, keyBytes []byte
-
-		err error
 	)
 
-	if t.settings.CAFile != "" {
-		caBytes, err = os.ReadFile(t.settings.CAFile)
+	if t.settings.CA != nil {
+		ca, err := t.settings.CA.fetch(ctx)
 		if err != nil {
-			return nil, nil, nil, nil, err
+			return nil, nil, nil, nil, fmt.Errorf("unable to read CA cert: %w", err)
 		}
-	} else if t.settings.CA != "" {
-		caBytes = []byte(t.settings.CA)
+		caBytes = []byte(ca)
 	}
 
-	if t.settings.CertFile != "" {
-		certBytes, err = os.ReadFile(t.settings.CertFile)
+	if t.settings.Cert != nil {
+		cert, err := t.settings.Cert.fetch(ctx)
 		if err != nil {
-			return nil, nil, nil, nil, err
+			return nil, nil, nil, nil, fmt.Errorf("unable to read client cert: %w", err)
 		}
-	} else if t.settings.Cert != "" {
-		certBytes = []byte(t.settings.Cert)
+		certBytes = []byte(cert)
 	}
 
-	if t.settings.KeyFile != "" {
-		keyBytes, err = os.ReadFile(t.settings.KeyFile)
+	if t.settings.Key != nil {
+		key, err := t.settings.Key.fetch(ctx)
 		if err != nil {
-			return nil, nil, nil, nil, err
+			return nil, nil, nil, nil, fmt.Errorf("unable to read client key: %w", err)
 		}
-	} else if t.settings.Key != "" {
-		keyBytes = []byte(t.settings.Key)
+		keyBytes = []byte(key)
 	}
 
 	var caHash, certHash, keyHash [32]byte
@@ -1112,7 +1266,7 @@ func (t *tlsRoundTripper) getTLSDataWithHash() ([]byte, []byte, []byte, []byte, 
 
 // RoundTrip implements the http.RoundTrip interface.
 func (t *tlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	caData, caHash, certHash, keyHash, err := t.getTLSDataWithHash()
+	caData, caHash, certHash, keyHash, err := t.getTLSDataWithHash(req.Context())
 	if err != nil {
 		return nil, err
 	}
@@ -1133,7 +1287,7 @@ func (t *tlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	// using GetClientCertificate.
 	tlsConfig := t.tlsConfig.Clone()
 	if !updateRootCA(tlsConfig, caData) {
-		return nil, fmt.Errorf("unable to use specified CA cert %s", t.settings.CAFile)
+		return nil, fmt.Errorf("unable to use specified CA cert %s", t.settings.CA.description())
 	}
 	rt, err = t.newRT(tlsConfig)
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -89,11 +89,12 @@ github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/options
 github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/shared
 github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/version
 github.com/AzureAD/microsoft-authentication-library-for-go/apps/public
-# github.com/GoogleCloudPlatform/prometheus-engine v0.11.0-rc.0
+# github.com/GoogleCloudPlatform/prometheus-engine v0.11.0-rc.2
 ## explicit; go 1.21
 github.com/GoogleCloudPlatform/prometheus-engine/pkg/export
 github.com/GoogleCloudPlatform/prometheus-engine/pkg/export/setup
 github.com/GoogleCloudPlatform/prometheus-engine/pkg/lease
+github.com/GoogleCloudPlatform/prometheus-engine/pkg/secrets
 # github.com/Microsoft/go-winio v0.6.0
 ## explicit; go 1.17
 github.com/Microsoft/go-winio
@@ -243,8 +244,8 @@ github.com/fatih/color
 # github.com/felixge/httpsnoop v1.0.4
 ## explicit; go 1.13
 github.com/felixge/httpsnoop
-# github.com/fsnotify/fsnotify v1.6.0
-## explicit; go 1.16
+# github.com/fsnotify/fsnotify v1.7.0
+## explicit; go 1.17
 github.com/fsnotify/fsnotify
 # github.com/ghodss/yaml v1.0.0
 ## explicit
@@ -628,7 +629,7 @@ github.com/prometheus/client_golang/prometheus/testutil/promlint/validations
 # github.com/prometheus/client_model v0.5.0
 ## explicit; go 1.19
 github.com/prometheus/client_model/go
-# github.com/prometheus/common v0.45.0 => github.com/TheSpiritXIII/prometheus-common v0.45.0-gmp.0
+# github.com/prometheus/common v0.47.0 => github.com/TheSpiritXIII/prometheus-common v0.45.0-gmp.1
 ## explicit; go 1.20
 github.com/prometheus/common/config
 github.com/prometheus/common/expfmt
@@ -1403,6 +1404,6 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/prometheus/common => github.com/TheSpiritXIII/prometheus-common v0.45.0-gmp.0
+# github.com/prometheus/common => github.com/TheSpiritXIII/prometheus-common v0.45.0-gmp.1
 # k8s.io/klog => github.com/simonpasquier/klog-gokit v0.3.0
 # k8s.io/klog/v2 => github.com/simonpasquier/klog-gokit/v3 v3.4.0


### PR DESCRIPTION
prometheus-engine change here: https://github.com/GoogleCloudPlatform/prometheus-engine/pull/864

The HTTP Client configuration was expanded to include:

```yaml
basic_auth:
  [ password_ref: [<string>](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#string) ]
authorization:
  [ credentials_ref: [<secret>](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#secret) ]
oauth2:
  [ client_secret_ref: [<secret>](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#secret) ]
tls_config:
  [ ca_ref: [<secret>](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#secret) ]
  [ cert_ref: [<secret>](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#secret) ]
  [ key_ref: [<secret>](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#secret) ]
```

The [root configuration](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config) now includes:

```yaml
kubernetes_sp_config:
  # The information to access the Kubernetes API.

  # The API server addresses. If left empty, Prometheus is assumed to run inside
  # of the cluster and will discover API servers automatically and use the pod's
  # CA certificate and bearer token file at /var/run/secrets/kubernetes.io/serviceaccount/.
  [ api_server: [<host>](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#host) ]

  # Optional path to a kubeconfig file.
  # Note that api_server and kube_config are mutually exclusive.
  [ kubeconfig_file: [<filename>](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#filename) ]

kubernetes_secrets:
# The name of the secret (used in secret ref in HTTPClientConfig.
- name: [<string>](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#string)
  config:
    # The namespace of the Kubernetes Secret to use.
    namespace: [<string>](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#string)
    # The name of the Kubernetes Secret to use.
    name: [<string>](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#string)
    # The key of the Kubernetes Secret to use.
    key: [<string>](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#string)
```

This is all protected under the `google-kubernetes-secret-provider` feature flag, to be replaced should we merge this functionality upstream.