### PR TITLE
chore: enable cgo and use google buildbase

### DIFF
--- a/cmd/prometheus/boring.go
+++ b/cmd/prometheus/boring.go
@@ -1,0 +1,21 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build boring
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+)


### PR DESCRIPTION
cgo needs to be enabled to link against boringcrypto, so we add that
here.

In addition, we use the google-go.pkg.dev/golang image as the Go
buildbase to ensure build-time requirements, like boringcrypto, are
enabled.

We also use gke.gcr.io/gke-distroless/libc as our runtime image.

We add the "cryp/tls/fipsonly" import to ensure boringcrypto is
linking properly at build time. We guard this with a build tag
"boring" in a dedicated file.

Finally, we remove promtool from the image, as its not intended to be
used.
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
