### PR TITLE
fix: Use upstream go image for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG IMAGE_BUILD_NODEJS=launcher.gcr.io/google/nodejs
-ARG IMAGE_BUILD_GO=google-go.pkg.dev/golang:1.20.14@sha256:6f86d8a81ff191bee8d3ff8b4c193889560b4ca15df373d5084953c5c860190f
+ARG IMAGE_BUILD_GO=golang:1.20.14@sha256:8f9af7094d0cb27cc783c697ac5ba25efdc4da35f8526db21f7aebb0b0b4f18a
 ARG IMAGE_BASE_DEBUG=gcr.io/distroless/static-debian11:debug
 ARG IMAGE_BASE=gke.gcr.io/gke-distroless/libc@sha256:4f834e207f2721977094aeec4c9daee7032c5daec2083c0be97760f4306e4f88
 


### PR DESCRIPTION
This fixes an issue with images on ARM64.
Tested and verified fix on ARM64 and AMD64 machines.

Testing steps:
```
docker buildx build --builder mybuilder -t gcr.io/$PROJECT_ID/prometheus-engine/prometheus:arm-test1 . --platform linux/arm64,linux/amd64 --build-arg QEMU_VERSION=latest --push

# Add file to examples/prometheus.yaml and test
```