### PR TITLE
feat: allow updating export flags at runtime

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -233,6 +233,8 @@ type Config struct {
 
 	RemoteWriteConfigs []*RemoteWriteConfig `yaml:"remote_write,omitempty"`
 	RemoteReadConfigs  []*RemoteReadConfig  `yaml:"remote_read,omitempty"`
+
+	GoogleCloud *GoogleCloudConfig `yaml:"google_cloud,omitempty"`
 }
 
 // SetDirectory joins any relative file paths with dir.
@@ -1075,4 +1077,14 @@ func filePath(filename string) string {
 
 func fileErr(filename string, err error) error {
 	return fmt.Errorf("%q: %w", filePath(filename), err)
+}
+
+type GoogleCloudConfig struct {
+	Export *GoogleCloudExportConfig `yaml:"export,omitempty"`
+}
+
+type GoogleCloudExportConfig struct {
+	Match           []string `yaml:"match,omitempty"`
+	Compression     *string  `yaml:"compression,omitempty"`
+	CredentialsFile *string  `yaml:"credentials,omitempty"`
 }


### PR DESCRIPTION
This PR allows you to set Google Cloud Monitoring API export-related flags in the configuration, as opposed to the CLI. The main motivation for this change is to eliminate UPDATE RBAC permissions which are otherwise required to update the CLI flags at runtime in a Kubernetes environment.

The following are now settable in the Prometheus config:
```yaml
google_cloud:
  export:
    match: []string
    compression: string
    credentials: string
```

When both CLI arguments and configurations are present, the CLI arguments will be the default and the set configurations will override the CLI arguments.