### PR TITLE
chore: update to Golang 1.22.3 to match prometheus-engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,17 +61,18 @@ jobs:
           go test $TestTargets -vet=off -v
         shell: powershell
 
-  test_golang_oldest:
-    name: Go tests with previous Go version
-    runs-on: ubuntu-latest
-    # The go verson in this image should be N-1 wrt test_go.
-    container:
-      image: quay.io/prometheus/golang-builder:1.21-base
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - run: make build
-      - run: go test ./tsdb/...
-      - run: go test ./tsdb/ -test.tsdb-isolation=false
+  # Commented out because GMP doesn't support Golang 1.21 and 1.23 does not exist.
+  # test_golang_oldest:
+  #   name: Go tests with previous Go version
+  #   runs-on: ubuntu-latest
+  #   # The go verson in this image should be N-1 wrt test_go.
+  #   container:
+  #     image: quay.io/prometheus/golang-builder:1.21-base
+  #   steps:
+  #     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+  #     - run: make build
+  #     - run: go test ./tsdb/...
+  #     - run: go test ./tsdb/ -test.tsdb-isolation=false
 
   test_mixins:
     name: Mixins tests

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '>=1.21 <1.22'
+          go-version: '~1.22'
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG IMAGE_BUILD_NODEJS=launcher.gcr.io/google/nodejs
-ARG IMAGE_BUILD_GO=golang:1.20.14@sha256:8f9af7094d0cb27cc783c697ac5ba25efdc4da35f8526db21f7aebb0b0b4f18a
+ARG IMAGE_BUILD_GO=golang:1.22.3@sha256:f43c6f049f04cbbaeb28f0aad3eea15274a7d0a7899a617d0037aec48d7ab010 as buildbase
+
 ARG IMAGE_BASE_DEBUG=gcr.io/distroless/static-debian11:debug
 ARG IMAGE_BASE=gke.gcr.io/gke-distroless/libc@sha256:4f834e207f2721977094aeec4c9daee7032c5daec2083c0be97760f4306e4f88
 


### PR DESCRIPTION
This is necessary to update our prometheus-engine further.