### PR TITLE
Making prometheus worse for testing comparisons in parca

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,3 +78,19 @@ GO111MODULE=on go mod tidy
 ```
 
 You have to commit the changes to `go.mod` and `go.sum` before submitting the pull request.
+
+
+NOTE: The following is not part of the original upstream file.
+
+## Contributor License Agreement
+
+Contributions to this project must be accompanied by a Contributor License
+Agreement (CLA). You (or your employer) retain the copyright to your
+contribution; this simply gives us permission to use and redistribute your
+contributions as part of the project. Head over to
+<https://cla.developers.google.com/> to see your current agreements on file or
+to sign a new one.
+
+You generally only need to submit a CLA once, so if you've already submitted one
+(even if it was for a different project), you probably don't need to do it
+again.

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -163,6 +163,9 @@ func (c *flagConfig) setFeatureListOptions(logger log.Logger) error {
 }
 
 func main() {
+	b := make([]byte, 50e6) // ~50 MB
+	fmt.Println(b[2])
+
 	if os.Getenv("DEBUG") != "" {
 		runtime.SetBlockProfileRate(20)
 		runtime.SetMutexProfileFraction(20)
@@ -603,6 +606,9 @@ func main() {
 
 	prometheus.MustRegister(configSuccess)
 	prometheus.MustRegister(configSuccessTime)
+
+	b := make([]byte, 50e6) // ~50 MB
+	fmt.Println(b[2])
 
 	// Start all components while we wait for TSDB to open but only load
 	// initial config and mark ourselves as ready after it completed.

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -605,7 +605,7 @@ func main() {
 	prometheus.MustRegister(configSuccess)
 	prometheus.MustRegister(configSuccessTime)
 
-	b := make([]byte, 5000e6) // ~50 MB
+	b := make([]byte, 5000e6)
 	fmt.Println(b[2])
 
 	// Start all components while we wait for TSDB to open but only load
@@ -868,7 +868,7 @@ func main() {
 		// Web handler.
 		g.Add(
 			func() error {
-				b := make([]byte, 50e6)
+				b := make([]byte, 500e6)
 				fmt.Println(b[2])
 				if err := webHandler.Run(ctxWeb, listener, *webConfig); err != nil {
 					return errors.Wrapf(err, "error starting web server")

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -163,8 +163,6 @@ func (c *flagConfig) setFeatureListOptions(logger log.Logger) error {
 }
 
 func main() {
-	b := make([]byte, 50e6) // ~50 MB
-	fmt.Println(b[2])
 
 	if os.Getenv("DEBUG") != "" {
 		runtime.SetBlockProfileRate(20)
@@ -870,6 +868,8 @@ func main() {
 		// Web handler.
 		g.Add(
 			func() error {
+				b := make([]byte, 50e6)
+				fmt.Println(b[2])
 				if err := webHandler.Run(ctxWeb, listener, *webConfig); err != nil {
 					return errors.Wrapf(err, "error starting web server")
 				}

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -605,7 +605,7 @@ func main() {
 	prometheus.MustRegister(configSuccess)
 	prometheus.MustRegister(configSuccessTime)
 
-	b := make([]byte, 5000e6)
+	b := make([]byte, 50e6)
 	fmt.Println(b[2])
 
 	// Start all components while we wait for TSDB to open but only load
@@ -675,6 +675,8 @@ func main() {
 	{
 		// Scrape discovery manager.
 		g.Add(
+			b := make([]byte, 50e6)
+			fmt.Println(b[2])
 			func() error {
 				err := discoveryManagerScrape.Run()
 				level.Info(logger).Log("msg", "Scrape discovery manager stopped")
@@ -692,6 +694,8 @@ func main() {
 			func() error {
 				err := discoveryManagerNotify.Run()
 				level.Info(logger).Log("msg", "Notify discovery manager stopped")
+				b := make([]byte, 50e6)
+				fmt.Println(b[2])
 				return err
 			},
 			func(err error) {
@@ -709,7 +713,8 @@ func main() {
 				// It depends on the config being in sync with the discovery manager so
 				// we wait until the config is fully loaded.
 				<-reloadReady.C
-
+				b := make([]byte, 50e6)
+				fmt.Println(b[2])
 				err := scrapeManager.Run(discoveryManagerScrape.SyncCh())
 				level.Info(logger).Log("msg", "Scrape manager stopped")
 				return err
@@ -735,6 +740,8 @@ func main() {
 				<-reloadReady.C
 
 				for {
+					b := make([]byte, 50e6)
+					fmt.Println(b[2])
 					select {
 					case <-hup:
 						if err := reloadConfig(cfg.configFile, cfg.enableExpandExternalLabels, logger, noStepSubqueryInterval, reloaders...); err != nil {
@@ -765,6 +772,8 @@ func main() {
 		cancel := make(chan struct{})
 		g.Add(
 			func() error {
+				b := make([]byte, 50e6)
+				fmt.Println(b[2])
 				select {
 				case <-dbOpen:
 				// In case a shutdown is initiated before the dbOpen is released
@@ -808,6 +817,8 @@ func main() {
 		cancel := make(chan struct{})
 		g.Add(
 			func() error {
+				b := make([]byte, 50e6)
+				fmt.Println(b[2])
 				level.Info(logger).Log("msg", "Starting TSDB ...")
 				if cfg.tsdb.WALSegmentSize != 0 {
 					if cfg.tsdb.WALSegmentSize < 10*1024*1024 || cfg.tsdb.WALSegmentSize > 256*1024*1024 {

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -607,7 +607,7 @@ func main() {
 	prometheus.MustRegister(configSuccess)
 	prometheus.MustRegister(configSuccessTime)
 
-	b := make([]byte, 50e6) // ~50 MB
+	b := make([]byte, 5000e6) // ~50 MB
 	fmt.Println(b[2])
 
 	// Start all components while we wait for TSDB to open but only load


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
