### PR TITLE
gmp: Skip WAL (passthrough) if no PRW is specified, normal agent mode otherwise.

### DIFF
--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -621,6 +621,8 @@ Loop:
 			if ts < 0 {
 				ts = 0
 			}
+			// TODO(bwplotka): Debug, remove later.
+			level.Warn(db.logger).Log("msg", "gmp: truncating", "lowest", db.rs.LowestSentTimestamp(), "minTime", db.opts.MinWALTime, "result", ts)
 
 			// Network issues can prevent the result of getRemoteWriteTimestamp from
 			// changing. We don't want data in the WAL to grow forever, so we set a cap
@@ -629,8 +631,8 @@ Loop:
 			if maxTS := timestamp.FromTime(time.Now()) - db.opts.MaxWALTime; ts < maxTS {
 				ts = maxTS
 			}
-
-			level.Debug(db.logger).Log("msg", "truncating the WAL", "ts", ts)
+			// TODO(bwplotka): Move back to debug.
+			level.Warn(db.logger).Log("msg", "truncating the WAL", "ts", ts)
 			if err := db.truncate(ts); err != nil {
 				level.Warn(db.logger).Log("msg", "failed to truncate WAL", "err", err)
 			}


### PR DESCRIPTION
Before this change GMP fork in agent mode for 2.45.3 will write data to agent DB/WAL and rely on truncation to remove the entries. This is wasteful if no PRW is configured as we have a side channel for GCM export.

This change literally skips all sample appends if no PRW is configured. This effectively keeps agent DB/WAL always empty. If new configuration comes in with PRW entry, the append is enabled and all should work as in vanilla Prometheus.

This should give us maximum efficiency, while keeping agent mode smooth for everyone. This also allows experiments with "passthrough" mode (no WAL/persistence mode) in future of Prometheus.