### PR TITLE
chore: rebase `feature/shutdownscrape` on v2.54.1

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1058,9 +1058,9 @@ func main() {
 				// we wait until the config is fully loaded.
 				<-reloadReady.C
 
-				err := scrapeManager.Run(discoveryManagerScrape.SyncCh())
+				scrapeManager.Run(discoveryManagerScrape.SyncCh())
 				level.Info(logger).Log("msg", "Scrape manager stopped")
-				return err
+				return nil
 			},
 			func(err error) {
 				// Scrape manager needs to be stopped before closing the local TSDB

--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -805,12 +805,12 @@ func TestTargetSetTargetGroupsPresentOnStartup(t *testing.T) {
 	discoveryManager.ApplyConfig(c)
 
 	syncedTargets := <-discoveryManager.SyncCh()
-	require.Equal(t, 1, len(syncedTargets))
+	require.Len(t, syncedTargets, 1)
 	verifySyncedPresence(t, syncedTargets, "prometheus", "{__address__=\"foo:9090\"}", true)
-	require.Equal(t, 1, len(syncedTargets["prometheus"]))
+	require.Len(t, syncedTargets["prometheus"], 1)
 	p := pk("static", "prometheus", 0)
 	verifyPresence(t, discoveryManager.targets, p, "{__address__=\"foo:9090\"}", true)
-	require.Equal(t, 1, len(discoveryManager.targets))
+	require.Len(t, discoveryManager.targets, 1)
 }
 
 func TestTargetSetTargetGroupsPresentOnConfigReload(t *testing.T) {

--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -784,6 +784,35 @@ func pk(provider, setName string, n int) poolKey {
 	}
 }
 
+func TestTargetSetTargetGroupsPresentOnStartup(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	reg := prometheus.NewRegistry()
+	_, sdMetrics := NewTestMetrics(t, reg)
+
+	discoveryManager := NewManager(ctx, log.NewNopLogger(), reg, sdMetrics, SkipInitialWait())
+
+	// Set the updatert to a super long time so we can verify that the skip worked correctly.
+	discoveryManager.updatert = 100 * time.Hour
+	go discoveryManager.Run()
+
+	c := map[string]Configs{
+		"prometheus": {
+			staticConfig("foo:9090"),
+		},
+	}
+	discoveryManager.ApplyConfig(c)
+
+	syncedTargets := <-discoveryManager.SyncCh()
+	require.Equal(t, 1, len(syncedTargets))
+	verifySyncedPresence(t, syncedTargets, "prometheus", "{__address__=\"foo:9090\"}", true)
+	require.Equal(t, 1, len(syncedTargets["prometheus"]))
+	p := pk("static", "prometheus", 0)
+	verifyPresence(t, discoveryManager.targets, p, "{__address__=\"foo:9090\"}", true)
+	require.Equal(t, 1, len(discoveryManager.targets))
+}
+
 func TestTargetSetTargetGroupsPresentOnConfigReload(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -89,6 +89,13 @@ type Options struct {
 	// Optional HTTP client options to use when scraping.
 	HTTPClientOptions []config_util.HTTPClientOption
 
+	// IgnoreJitter causes all targets managed by this manager to be scraped
+	// as soon as they are discovered. By default, all targets have offset,
+	// so we spread the scraping load evenly within Prometheus server.
+	// NOTE(bwplotka): This option is experimental and not used by Prometheus.
+	// It was created for serverless flavors of OpenTelemetry contrib's prometheusreceiver.
+	IgnoreJitter bool
+
 	// private option for testability.
 	skipOffsetting bool
 }
@@ -115,7 +122,7 @@ type Manager struct {
 
 // Run receives and saves target set updates and triggers the scraping loops reloading.
 // Reloading happens in the background so that it doesn't block receiving targets updates.
-func (m *Manager) Run(tsets <-chan map[string][]*targetgroup.Group) error {
+func (m *Manager) Run(tsets <-chan map[string][]*targetgroup.Group) {
 	go m.reloader()
 	for {
 		select {
@@ -128,7 +135,7 @@ func (m *Manager) Run(tsets <-chan map[string][]*targetgroup.Group) error {
 			}
 
 		case <-m.graceShut:
-			return nil
+			return
 		}
 	}
 }
@@ -212,6 +219,40 @@ func (m *Manager) setOffsetSeed(labels labels.Labels) error {
 func (m *Manager) Stop() {
 	m.mtxScrape.Lock()
 	defer m.mtxScrape.Unlock()
+
+	for _, sp := range m.scrapePools {
+		sp.stop()
+	}
+	close(m.graceShut)
+}
+
+// StopAfterScrapeAttempt stops manager after ensuring all targets' last scrape
+// attempt happened after minScrapeTime. It cancels all running scrape pools and
+// blocks until all have exited.
+//
+// It is likely that such shutdown scrape will cause irregular scrape interval and
+// sudden efficiency (memory, CPU) spikes. However, it can be a fair tradeoff for
+// short-lived and small number of targets, where at least one or two samples could be
+// preserved (and ideally aggregated further by separate processes).
+//
+// NOTE(bwplotka): This method is experimental and not used by Prometheus.
+// It was created for serverless flavors of OpenTelemetry contrib's prometheusreceiver.
+func (m *Manager) StopAfterScrapeAttempt(minScrapeTime time.Time) {
+	m.mtxScrape.Lock()
+	defer m.mtxScrape.Unlock()
+
+	var wg sync.WaitGroup
+	for _, p := range m.scrapePools {
+		for _, l := range p.loops {
+			l := l
+			wg.Add(1)
+			go func() {
+				l.stopAfterScrapeAttempt(minScrapeTime)
+				wg.Done()
+			}()
+		}
+	}
+	wg.Wait()
 
 	for _, sp := range m.scrapePools {
 		sp.stop()

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -89,12 +89,18 @@ type Options struct {
 	// Optional HTTP client options to use when scraping.
 	HTTPClientOptions []config_util.HTTPClientOption
 
-	// IgnoreJitter causes all targets managed by this manager to be scraped
-	// as soon as they are discovered. By default, all targets have offset,
-	// so we spread the scraping load evenly within Prometheus server.
+	// InitialScrapeOffset controls how long after startup we should scrape all
+	// targets.  By default, all targets have an offset so we spread the
+	// scraping load evenly within the Prometheus server. Configuring this will
+	// make it so all targets have the same configured offset, which may be
+	// undesirable as load is no longer evenly spread.  This is useful however
+	// in serverless deployments where we're sensitive to the intitial offsets
+	// and would like them to be small and configurable.
+	//
 	// NOTE(bwplotka): This option is experimental and not used by Prometheus.
-	// It was created for serverless flavors of OpenTelemetry contrib's prometheusreceiver.
-	IgnoreJitter bool
+	// It was created for serverless flavors of OpenTelemetry contrib's
+	// prometheusreceiver.
+	InitialScrapeOffset *time.Duration
 
 	// private option for testability.
 	skipOffsetting bool

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -264,6 +264,7 @@ func (m *Manager) StopAfterScrapeAttempt(minScrapeTime time.Time) {
 
 	var wg sync.WaitGroup
 	for _, p := range m.scrapePools {
+		p.mtx.Lock()
 		for _, l := range p.loops {
 			l := l
 			wg.Add(1)
@@ -272,6 +273,7 @@ func (m *Manager) StopAfterScrapeAttempt(minScrapeTime time.Time) {
 				wg.Done()
 			}()
 		}
+		p.mtx.Unlock()
 	}
 	wg.Wait()
 

--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -611,6 +611,46 @@ func TestManagerTargetsUpdates(t *testing.T) {
 	}
 }
 
+func TestManagerSkipInitialWait(t *testing.T) {
+	opts := Options{DiscoveryReloadOnStartup: true}
+	testRegistry := prometheus.NewRegistry()
+	m, err := NewManager(&opts, nil, nil, testRegistry)
+	require.NoError(t, err)
+
+	ts := make(chan map[string][]*targetgroup.Group, 1)
+	go m.Run(ts)
+	defer m.Stop()
+
+	tgSent := make(map[string][]*targetgroup.Group)
+	tgSent["test"] = []*targetgroup.Group{
+		{
+			Source: "test_source",
+		},
+	}
+
+	select {
+	case ts <- tgSent:
+	case <-time.After(10 * time.Millisecond):
+		t.Error("Scrape manager's channel remained blocked after the set threshold.")
+	}
+
+	// Give some time for the reloader to have picked this up.
+	time.Sleep(2 * time.Second)
+
+	m.mtxScrape.Lock()
+	tsetActual := m.targetSets
+	m.mtxScrape.Unlock()
+
+	// Make sure all updates have been received.
+	require.Equal(t, tgSent, tsetActual)
+
+	select {
+	case <-m.triggerReload:
+		t.Error("Reload should've already happened")
+	default:
+	}
+}
+
 func TestSetOffsetSeed(t *testing.T) {
 	getConfig := func(prometheus string) *config.Config {
 		cfgText := `

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1221,8 +1221,10 @@ func (sl *scrapeLoop) run(errc chan<- error) {
 	defer close(sl.stopAfterScrapeAttemptCh)
 
 	jitterDelayTime := sl.scraper.offset(sl.interval, sl.offsetSeed)
-	if sl.opts.IgnoreJitter || sl.skipOffsetting {
+	if sl.skipOffsetting {
 		jitterDelayTime = 0 * time.Second
+	} else if sl.opts.InitialScrapeOffset != nil {
+		jitterDelayTime = *sl.opts.InitialScrapeOffset
 	}
 
 	select {

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -185,6 +185,10 @@ func (l *testLoop) stop() {
 	l.stopFunc()
 }
 
+func (l *testLoop) stopAfterScrapeAttempt(_ time.Time) {
+	l.stopFunc()
+}
+
 func (l *testLoop) getCache() *scrapeCache {
 	return nil
 }
@@ -282,6 +286,7 @@ func TestScrapePoolReload(t *testing.T) {
 		client:        http.DefaultClient,
 		metrics:       newTestScrapeMetrics(t),
 		symbolTable:   labels.NewSymbolTable(),
+		opts:          &Options{},
 	}
 
 	// Reloading a scrape pool with a new scrape configuration must stop all scrape
@@ -365,6 +370,7 @@ func TestScrapePoolReloadPreserveRelabeledIntervalTimeout(t *testing.T) {
 		client:      http.DefaultClient,
 		metrics:     newTestScrapeMetrics(t),
 		symbolTable: labels.NewSymbolTable(),
+		opts:        &Options{},
 	}
 
 	err := sp.reload(reloadCfg)
@@ -396,6 +402,7 @@ func TestScrapePoolTargetLimit(t *testing.T) {
 		client:        http.DefaultClient,
 		metrics:       newTestScrapeMetrics(t),
 		symbolTable:   labels.NewSymbolTable(),
+		opts:          &Options{},
 	}
 
 	tgs := []*targetgroup.Group{}
@@ -629,6 +636,7 @@ func TestScrapePoolScrapeLoopsStarted(t *testing.T) {
 		client:        http.DefaultClient,
 		metrics:       newTestScrapeMetrics(t),
 		symbolTable:   labels.NewSymbolTable(),
+		opts:          &Options{},
 	}
 
 	tgs := []*targetgroup.Group{
@@ -684,6 +692,7 @@ func newBasicScrapeLoop(t testing.TB, ctx context.Context, scraper scraper, app 
 		false,
 		newTestScrapeMetrics(t),
 		false,
+		nil,
 	)
 }
 
@@ -826,6 +835,7 @@ func TestScrapeLoopRun(t *testing.T) {
 		false,
 		scrapeMetrics,
 		false,
+		nil,
 	)
 
 	// The loop must terminate during the initial offset if the context
@@ -970,6 +980,7 @@ func TestScrapeLoopMetadata(t *testing.T) {
 		false,
 		scrapeMetrics,
 		false,
+		nil,
 	)
 	defer cancel()
 
@@ -3735,8 +3746,7 @@ scrape_configs:
 	mng.ApplyConfig(cfg)
 	tsets := make(chan map[string][]*targetgroup.Group)
 	go func() {
-		err = mng.Run(tsets)
-		require.NoError(t, err)
+		mng.Run(tsets)
 	}()
 	defer mng.Stop()
 

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -700,6 +700,10 @@ func TestScrapeLoopStopBeforeRun(t *testing.T) {
 	scraper := &testScraper{}
 	sl := newBasicScrapeLoop(t, context.Background(), scraper, nil, 1)
 
+	// The loop must terminate during the initial offset if the context
+	// is canceled.
+	scraper.offsetDur = time.Hour
+
 	// The scrape pool synchronizes on stopping scrape loops. However, new scrape
 	// loops are started asynchronously. Thus it's possible, that a loop is stopped
 	// again before having started properly.


### PR DESCRIPTION
Cherry-picks the commits from `feature/shutdownscrape` onto a mirror of v0.54.1