### PR TITLE
fix: use exportConfig fields only when not empty

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -881,7 +881,7 @@ func main() {
 				exporterOpts := opts.ExporterOpts
 				if cfg.GoogleCloud != nil && cfg.GoogleCloud.Export != nil {
 					exportConfig := cfg.GoogleCloud.Export
-					if exportConfig.Compression != nil {
+					if exportConfig.Compression != nil && *exportConfig.Compression != "" {
 						exporterOpts.Compression = *exportConfig.Compression
 					}
 					if exportConfig.Match != nil {
@@ -895,7 +895,7 @@ func main() {
 						}
 						exporterOpts.Matchers = selectors
 					}
-					if exportConfig.CredentialsFile != nil {
+					if exportConfig.CredentialsFile != nil && *exportConfig.CredentialsFile != "" {
 						exporterOpts.CredentialsFile = *exportConfig.CredentialsFile
 					}
 


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

`exportConfig.Compression` and `exportConfig.CredentialsFile` could be pointer to empty string, so add an additional check to only use the config from non-empty string.
