### PR TITLE
feat: Add populate description from help support

### DIFF
--- a/google/export/export.go
+++ b/google/export/export.go
@@ -224,6 +224,11 @@ type ExporterOpts struct {
 	// internal data structure sizes. Only for advance users. No compatibility
 	// guarantee (might change in future).
 	Efficiency EfficiencyOpts
+
+	// Feature flags.
+	// PopulateDescription controls the help -> description setting.
+	// TODO(bwplotka): Promote this flag to have default "true" if we gain confidence.
+	PopulateDescription bool
 }
 
 // DefaultUnsetFields defaults any zero-valued fields.
@@ -405,11 +410,13 @@ func New(ctx context.Context, logger log.Logger, reg prometheus.Registerer, opts
 	}
 
 	e := &Exporter{
-		logger:               logger,
-		ctx:                  ctx,
-		opts:                 opts,
-		metricClient:         metricClient,
-		seriesCache:          newSeriesCache(logger, reg, opts.MetricTypePrefix, opts.Matchers),
+		logger:       logger,
+		ctx:          ctx,
+		opts:         opts,
+		metricClient: metricClient,
+		// TODO(bwpotka): Consider recreation on ApplyConfig for hot-reloading support.
+		// See related discussion in
+		seriesCache:          newSeriesCache(logger, reg, opts.MetricTypePrefix, opts.Matchers, opts.PopulateDescription),
 		externalLabels:       createLabelSet(&config.Config{}, &opts),
 		newMetricClient:      defaultNewMetricClient,
 		nextc:                make(chan struct{}, 1),

--- a/google/export/export.go
+++ b/google/export/export.go
@@ -224,11 +224,6 @@ type ExporterOpts struct {
 	// internal data structure sizes. Only for advance users. No compatibility
 	// guarantee (might change in future).
 	Efficiency EfficiencyOpts
-
-	// Feature flags.
-	// PopulateDescription controls the help -> description setting.
-	// TODO(bwplotka): Promote this flag to have default "true" if we gain confidence.
-	PopulateDescription bool
 }
 
 // DefaultUnsetFields defaults any zero-valued fields.
@@ -410,13 +405,11 @@ func New(ctx context.Context, logger log.Logger, reg prometheus.Registerer, opts
 	}
 
 	e := &Exporter{
-		logger:       logger,
-		ctx:          ctx,
-		opts:         opts,
-		metricClient: metricClient,
-		// TODO(bwpotka): Consider recreation on ApplyConfig for hot-reloading support.
-		// See related discussion in
-		seriesCache:          newSeriesCache(logger, reg, opts.MetricTypePrefix, opts.Matchers, opts.PopulateDescription),
+		logger:               logger,
+		ctx:                  ctx,
+		opts:                 opts,
+		metricClient:         metricClient,
+		seriesCache:          newSeriesCache(logger, reg, opts.MetricTypePrefix, opts.Matchers),
 		externalLabels:       createLabelSet(&config.Config{}, &opts),
 		newMetricClient:      defaultNewMetricClient,
 		nextc:                make(chan struct{}, 1),

--- a/google/export/series_cache.go
+++ b/google/export/series_cache.go
@@ -64,6 +64,14 @@ type seriesCache struct {
 
 	// Prefix under which metrics are written to GCM.
 	metricTypePrefix string
+
+	// Feature flag that controls passing the HELP of the metric as a GCM
+	// metric description. This was historically not done to avoid the GCM
+	// limitation in handling description changes, often possible in OSS metric
+	// world (Prometheus, Otel). As of 2025 Q1 this has been now fixed, but
+	// we maintain feature flag so we can rollback on scale in case of the
+	// handling issues.
+	populateDescription bool
 }
 
 type seriesCacheEntry struct {
@@ -133,21 +141,23 @@ func (e *seriesCacheEntry) setNextRefresh() {
 }
 
 func newSeriesCache(
-	logger log.Logger,
-	reg prometheus.Registerer,
-	metricTypePrefix string,
-	matchers Matchers,
+		logger log.Logger,
+		reg prometheus.Registerer,
+		metricTypePrefix string,
+		matchers Matchers,
+		populateDescription bool,
 ) *seriesCache {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
 	return &seriesCache{
-		logger:           logger,
-		now:              time.Now,
-		pool:             newPool(reg),
-		entries:          map[storage.SeriesRef]*seriesCacheEntry{},
-		matchers:         matchers,
-		metricTypePrefix: metricTypePrefix,
+		logger:              logger,
+		now:                 time.Now,
+		pool:                newPool(reg),
+		entries:             map[storage.SeriesRef]*seriesCacheEntry{},
+		matchers:            matchers,
+		metricTypePrefix:    metricTypePrefix,
+		populateDescription: populateDescription,
 	}
 }
 
@@ -393,12 +403,13 @@ func (c *seriesCache) populate(ref storage.SeriesRef, entry *seriesCacheEntry, e
 		metricLabels = metricLabelsBuilder.Labels()
 	}
 
-	newSeries := func(mtype string, kind metric_pb.MetricDescriptor_MetricKind, vtype metric_pb.MetricDescriptor_ValueType) hashedSeries {
+	newSeries := func(mType, mHelp string, kind metric_pb.MetricDescriptor_MetricKind, vtype metric_pb.MetricDescriptor_ValueType) hashedSeries {
 		s := &monitoring_pb.TimeSeries{
-			Resource:   resource,
-			Metric:     &metric_pb.Metric{Type: mtype, Labels: metricLabels.Map()},
-			MetricKind: kind,
-			ValueType:  vtype,
+			Resource:    resource,
+			Metric:      &metric_pb.Metric{Type: mType, Labels: metricLabels.Map()},
+			MetricKind:  kind,
+			ValueType:   vtype,
+			Description: mHelp,
 		}
 		return hashedSeries{hash: hashSeries(s), proto: s}
 	}
@@ -408,44 +419,58 @@ func (c *seriesCache) populate(ref storage.SeriesRef, entry *seriesCacheEntry, e
 	case model.MetricTypeCounter:
 		protos.cumulative = newSeries(
 			c.getMetricType(metricName, gcmMetricSuffixCounter, gcmMetricSuffixNone),
+			metadata.Help,
 			metric_pb.MetricDescriptor_CUMULATIVE,
-			metric_pb.MetricDescriptor_DOUBLE)
+			metric_pb.MetricDescriptor_DOUBLE,
+		)
 
 	case model.MetricTypeGauge:
 		protos.gauge = newSeries(
 			c.getMetricType(metricName, gcmMetricSuffixGauge, gcmMetricSuffixNone),
+			metadata.Help,
 			metric_pb.MetricDescriptor_GAUGE,
-			metric_pb.MetricDescriptor_DOUBLE)
+			metric_pb.MetricDescriptor_DOUBLE,
+		)
 
 	case model.MetricTypeUnknown:
 		protos.gauge = newSeries(
 			c.getMetricType(metricName, gcmMetricSuffixUnknown, gcmMetricSuffixNone),
+			metadata.Help,
 			metric_pb.MetricDescriptor_GAUGE,
-			metric_pb.MetricDescriptor_DOUBLE)
+			metric_pb.MetricDescriptor_DOUBLE,
+		)
 		protos.cumulative = newSeries(
 			c.getMetricType(metricName, gcmMetricSuffixUnknown, gcmMetricSuffixCounter),
+			metadata.Help,
 			metric_pb.MetricDescriptor_CUMULATIVE,
-			metric_pb.MetricDescriptor_DOUBLE)
+			metric_pb.MetricDescriptor_DOUBLE,
+		)
 
 	case model.MetricTypeSummary:
 		switch suffix {
 		case metricSuffixSum:
 			protos.cumulative = newSeries(
 				c.getMetricType(metricName, gcmMetricSuffixSummary, gcmMetricSuffixCounter),
+				metadata.Help,
 				metric_pb.MetricDescriptor_CUMULATIVE,
-				metric_pb.MetricDescriptor_DOUBLE)
+				metric_pb.MetricDescriptor_DOUBLE,
+			)
 
 		case metricSuffixCount:
 			protos.cumulative = newSeries(
 				c.getMetricType(metricName, gcmMetricSuffixSummary, gcmMetricSuffixNone),
+				metadata.Help,
 				metric_pb.MetricDescriptor_CUMULATIVE,
-				metric_pb.MetricDescriptor_DOUBLE)
+				metric_pb.MetricDescriptor_DOUBLE,
+			)
 
 		case metricSuffixNone: // Actual quantiles.
 			protos.gauge = newSeries(
 				c.getMetricType(metricName, gcmMetricSuffixSummary, gcmMetricSuffixNone),
+				metadata.Help,
 				metric_pb.MetricDescriptor_GAUGE,
-				metric_pb.MetricDescriptor_DOUBLE)
+				metric_pb.MetricDescriptor_DOUBLE,
+			)
 
 		default:
 			return fmt.Errorf("unexpected metric name suffix %q for metric %q", suffix, metricName)
@@ -454,8 +479,10 @@ func (c *seriesCache) populate(ref storage.SeriesRef, entry *seriesCacheEntry, e
 	case model.MetricTypeHistogram:
 		protos.cumulative = newSeries(
 			c.getMetricType(baseMetricName, gcmMetricSuffixHistogram, gcmMetricSuffixNone),
+			metadata.Help,
 			metric_pb.MetricDescriptor_CUMULATIVE,
-			metric_pb.MetricDescriptor_DISTRIBUTION)
+			metric_pb.MetricDescriptor_DISTRIBUTION,
+		)
 
 	default:
 		return fmt.Errorf("unexpected metric type %s for metric %q", metadata.Type, metricName)

--- a/google/export/series_cache.go
+++ b/google/export/series_cache.go
@@ -64,14 +64,6 @@ type seriesCache struct {
 
 	// Prefix under which metrics are written to GCM.
 	metricTypePrefix string
-
-	// Feature flag that controls passing the HELP of the metric as a GCM
-	// metric description. This was historically not done to avoid the GCM
-	// limitation in handling description changes, often possible in OSS metric
-	// world (Prometheus, Otel). As of 2025 Q1 this has been now fixed, but
-	// we maintain feature flag so we can rollback on scale in case of the
-	// handling issues.
-	populateDescription bool
 }
 
 type seriesCacheEntry struct {
@@ -141,23 +133,21 @@ func (e *seriesCacheEntry) setNextRefresh() {
 }
 
 func newSeriesCache(
-		logger log.Logger,
-		reg prometheus.Registerer,
-		metricTypePrefix string,
-		matchers Matchers,
-		populateDescription bool,
+	logger log.Logger,
+	reg prometheus.Registerer,
+	metricTypePrefix string,
+	matchers Matchers,
 ) *seriesCache {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
 	return &seriesCache{
-		logger:              logger,
-		now:                 time.Now,
-		pool:                newPool(reg),
-		entries:             map[storage.SeriesRef]*seriesCacheEntry{},
-		matchers:            matchers,
-		metricTypePrefix:    metricTypePrefix,
-		populateDescription: populateDescription,
+		logger:           logger,
+		now:              time.Now,
+		pool:             newPool(reg),
+		entries:          map[storage.SeriesRef]*seriesCacheEntry{},
+		matchers:         matchers,
+		metricTypePrefix: metricTypePrefix,
 	}
 }
 

--- a/google/export/transform_test.go
+++ b/google/export/transform_test.go
@@ -102,8 +102,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1/gauge",
 						Labels: map[string]string{"k1": "v1"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_GAUGE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_GAUGE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							EndTime: &timestamp_pb.Timestamp{Seconds: 3},
@@ -129,8 +130,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1/gauge",
 						Labels: map[string]string{"k1": "v1"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_GAUGE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_GAUGE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							EndTime: &timestamp_pb.Timestamp{Seconds: 4},
@@ -171,8 +173,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1/unknown",
 						Labels: map[string]string{"k1": "v1"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_GAUGE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_GAUGE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							EndTime: &timestamp_pb.Timestamp{Seconds: 3},
@@ -198,8 +201,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1/unknown",
 						Labels: map[string]string{"k1": "v1"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_GAUGE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_GAUGE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							EndTime: &timestamp_pb.Timestamp{Seconds: 4},
@@ -225,8 +229,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1/unknown:counter",
 						Labels: map[string]string{"k1": "v1"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_CUMULATIVE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							StartTime: &timestamp_pb.Timestamp{Seconds: 3},
@@ -241,7 +246,7 @@ func TestSampleBuilder(t *testing.T) {
 		}, {
 			doc: "convert counter (Prometheus format metadata key)",
 			metadata: testMetadataFunc(metricMetadataMap{
-				"metric1_total": {Type: model.MetricTypeCounter, Help: "metric1 help text"},
+				"metric1_total": {Type: model.MetricTypeCounter, Help: "metric1_total help text"},
 			}),
 			series: seriesMap{
 				123: labels.FromStrings("job", "job1", "instance", "instance1", "__name__", "metric1_total", "k1", "v1"),
@@ -271,8 +276,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1_total/counter",
 						Labels: map[string]string{"k1": "v1"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_CUMULATIVE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1_total help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							StartTime: &timestamp_pb.Timestamp{Seconds: 2},
@@ -299,8 +305,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1_total/counter",
 						Labels: map[string]string{"k1": "v1"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_CUMULATIVE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1_total help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							StartTime: &timestamp_pb.Timestamp{Seconds: 2},
@@ -329,8 +336,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1_total/counter",
 						Labels: map[string]string{"k1": "v1"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_CUMULATIVE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1_total help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							StartTime: &timestamp_pb.Timestamp{Seconds: 4, Nanos: 999000000},
@@ -345,7 +353,7 @@ func TestSampleBuilder(t *testing.T) {
 		}, {
 			doc: "convert counter - skip duplicates (OpenMetrics format metadata key)",
 			metadata: testMetadataFunc(metricMetadataMap{
-				"metric1": {Type: model.MetricTypeCounter, Help: "metric1 help text"},
+				"metric1": {Type: model.MetricTypeCounter, Help: "metric1_total help text"},
 			}),
 			series: seriesMap{
 				123: labels.FromStrings("job", "job1", "instance", "instance1", "__name__", "metric1_total", "k1", "v1"),
@@ -381,8 +389,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1_total/counter",
 						Labels: map[string]string{"k1": "v1"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_CUMULATIVE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1_total help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							StartTime: &timestamp_pb.Timestamp{Seconds: 2},
@@ -411,8 +420,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1_total/counter",
 						Labels: map[string]string{"k1": "v1"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_CUMULATIVE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1_total help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							StartTime: &timestamp_pb.Timestamp{Seconds: 4, Nanos: 999000000},
@@ -440,8 +450,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1_total/counter",
 						Labels: map[string]string{"k1": "v1"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_CUMULATIVE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1_total help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							StartTime: &timestamp_pb.Timestamp{Seconds: 4, Nanos: 999000000},
@@ -509,8 +520,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1/summary",
 						Labels: map[string]string{"quantile": "0.5"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_GAUGE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_GAUGE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							EndTime: &timestamp_pb.Timestamp{Seconds: 2},
@@ -537,8 +549,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1_sum/summary:counter",
 						Labels: map[string]string{},
 					},
-					MetricKind: metric_pb.MetricDescriptor_CUMULATIVE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							StartTime: &timestamp_pb.Timestamp{Seconds: 2},
@@ -565,8 +578,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1_count/summary",
 						Labels: map[string]string{},
 					},
-					MetricKind: metric_pb.MetricDescriptor_CUMULATIVE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							StartTime: &timestamp_pb.Timestamp{Seconds: 3},
@@ -593,8 +607,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1/summary",
 						Labels: map[string]string{"quantile": "0.9"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_GAUGE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_GAUGE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							EndTime: &timestamp_pb.Timestamp{Seconds: 4},
@@ -645,8 +660,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1/summary",
 						Labels: map[string]string{"quantile": "0.5"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_GAUGE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_GAUGE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							EndTime: &timestamp_pb.Timestamp{Seconds: 2},
@@ -674,8 +690,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1_count/summary",
 						Labels: map[string]string{},
 					},
-					MetricKind: metric_pb.MetricDescriptor_CUMULATIVE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							StartTime: &timestamp_pb.Timestamp{Seconds: 3},
@@ -702,8 +719,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1/summary",
 						Labels: map[string]string{"quantile": "0.9"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_GAUGE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_GAUGE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							EndTime: &timestamp_pb.Timestamp{Seconds: 4},
@@ -799,8 +817,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1/histogram",
 						Labels: map[string]string{},
 					},
-					MetricKind: metric_pb.MetricDescriptor_CUMULATIVE,
-					ValueType:  metric_pb.MetricDescriptor_DISTRIBUTION,
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DISTRIBUTION,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							StartTime: &timestamp_pb.Timestamp{Seconds: 1},
@@ -842,8 +861,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1/histogram",
 						Labels: map[string]string{"a": "b"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_CUMULATIVE,
-					ValueType:  metric_pb.MetricDescriptor_DISTRIBUTION,
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DISTRIBUTION,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							StartTime: &timestamp_pb.Timestamp{Seconds: 1},
@@ -884,8 +904,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1_a_count/gauge",
 						Labels: map[string]string{"a": "b"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_GAUGE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1_a_count help text",
+					MetricKind:  metric_pb.MetricDescriptor_GAUGE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							EndTime: &timestamp_pb.Timestamp{Seconds: 1},
@@ -987,8 +1008,9 @@ func TestSampleBuilder(t *testing.T) {
 					Metric: &metric_pb.Metric{
 						Type: "prometheus.googleapis.com/metric1/histogram",
 					},
-					MetricKind: metric_pb.MetricDescriptor_CUMULATIVE,
-					ValueType:  metric_pb.MetricDescriptor_DISTRIBUTION,
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DISTRIBUTION,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							StartTime: &timestamp_pb.Timestamp{Seconds: 1},
@@ -1054,8 +1076,9 @@ func TestSampleBuilder(t *testing.T) {
 					Metric: &metric_pb.Metric{
 						Type: "prometheus.googleapis.com/metric1/histogram",
 					},
-					MetricKind: metric_pb.MetricDescriptor_CUMULATIVE,
-					ValueType:  metric_pb.MetricDescriptor_DISTRIBUTION,
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DISTRIBUTION,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							StartTime: &timestamp_pb.Timestamp{Seconds: 1},
@@ -1138,8 +1161,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1/gauge",
 						Labels: map[string]string{"k1": "v1"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_GAUGE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_GAUGE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							EndTime: &timestamp_pb.Timestamp{Seconds: 1},
@@ -1164,8 +1188,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1/gauge",
 						Labels: map[string]string{"k1": "v1"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_GAUGE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_GAUGE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							EndTime: &timestamp_pb.Timestamp{Seconds: 2},
@@ -1191,8 +1216,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1/gauge",
 						Labels: map[string]string{"k1": "v4"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_GAUGE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_GAUGE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							EndTime: &timestamp_pb.Timestamp{Seconds: 1},
@@ -1249,8 +1275,9 @@ func TestSampleBuilder(t *testing.T) {
 					Metric: &metric_pb.Metric{
 						Type: "prometheus.googleapis.com/metric1/histogram",
 					},
-					MetricKind: metric_pb.MetricDescriptor_CUMULATIVE,
-					ValueType:  metric_pb.MetricDescriptor_DISTRIBUTION,
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DISTRIBUTION,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							StartTime: &timestamp_pb.Timestamp{Seconds: 1},
@@ -1394,8 +1421,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1/histogram",
 						Labels: map[string]string{},
 					},
-					MetricKind: metric_pb.MetricDescriptor_CUMULATIVE,
-					ValueType:  metric_pb.MetricDescriptor_DISTRIBUTION,
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DISTRIBUTION,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							StartTime: &timestamp_pb.Timestamp{Seconds: 1},
@@ -1460,7 +1488,7 @@ func TestSampleBuilder(t *testing.T) {
 		{
 			doc: "convert counter with exemplars (exemplars should be dropped)",
 			metadata: testMetadataFunc(metricMetadataMap{
-				"metric1_total": {Type: model.MetricTypeCounter, Help: "metric1 help text"},
+				"metric1_total": {Type: model.MetricTypeCounter, Help: "metric1_total help text"},
 			}),
 			series: seriesMap{
 				123: labels.FromStrings("job", "job1", "instance", "instance1", "__name__", "metric1_total", "k1", "v1"),
@@ -1497,8 +1525,9 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "prometheus.googleapis.com/metric1_total/counter",
 						Labels: map[string]string{"k1": "v1"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_CUMULATIVE,
-					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Description: "metric1_total help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
 							StartTime: &timestamp_pb.Timestamp{Seconds: 2},

--- a/google/internal/promqle2etest/backend_export_gcm.go
+++ b/google/internal/promqle2etest/backend_export_gcm.go
@@ -64,27 +64,33 @@ type LocalExportGCMBackend struct {
 
 func (l LocalExportGCMBackend) Ref() string { return l.Name }
 
-func (l LocalExportGCMBackend) StartAndWaitReady(t testing.TB, _ e2e.Environment) promqle2e.RunningBackend {
-	t.Helper()
-
-	ctx := t.Context()
-
-	creds, err := google.CredentialsFromJSON(ctx, l.GCMSA, gcm.DefaultAuthScopes()...)
-	if err != nil {
-		t.Fatalf("create credentials from JSON: %s", err)
-	}
-
-	// Fake, does not matter.
-	cluster := "pe-github-action"
-	location := "europe-west3-a"
-
+func createPromClientAgainstGCM(ctx context.Context, creds *google.Credentials) (v1.API, error) {
 	cl, err := api.NewClient(api.Config{
 		Address: fmt.Sprintf("https://monitoring.googleapis.com/v1/projects/%s/location/global/prometheus", creds.ProjectID),
 		Client:  oauth2.NewClient(ctx, creds.TokenSource),
 	})
 	if err != nil {
-		t.Fatalf("create Prometheus client: %s", err)
+		return nil, fmt.Errorf("create Prometheus client: %s", err)
 	}
+	return v1.NewAPI(cl), nil
+}
+
+func (l LocalExportGCMBackend) StartAndWaitReady(t testing.TB, _ e2e.Environment) promqle2e.RunningBackend {
+	t.Helper()
+
+	ctx := t.Context()
+	creds, err := google.CredentialsFromJSON(ctx, l.GCMSA, gcm.DefaultAuthScopes()...)
+	if err != nil {
+		t.Fatalf("create credentials from JSON: %s", err)
+	}
+	api, err := createPromClientAgainstGCM(ctx, creds)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fake, does not matter.
+	cluster := "pe-github-action"
+	location := "europe-west3-a"
 
 	exporterOpts := export.ExporterOpts{
 		UserAgentEnv:        "pe-github-action-test",
@@ -92,6 +98,7 @@ func (l LocalExportGCMBackend) StartAndWaitReady(t testing.TB, _ e2e.Environment
 		Location:            location,
 		ProjectID:           creds.ProjectID,
 		CredentialsFromJSON: l.GCMSA,
+		PopulateDescription: true,
 	}
 	exporterOpts.DefaultUnsetFields()
 	e, err := export.New(ctx, log.NewJSONLogger(os.Stderr), nil, exporterOpts, export.NopLease())
@@ -119,7 +126,7 @@ func (l LocalExportGCMBackend) StartAndWaitReady(t testing.TB, _ e2e.Environment
 		}
 	}()
 	return &runningLocalExportWithGCM{
-		api:         v1.NewAPI(cl),
+		api:         api,
 		e:           e,
 		labelsByRef: labelsByRef,
 		collectionLabels: map[string]string{

--- a/google/internal/promqle2etest/backend_export_gcm.go
+++ b/google/internal/promqle2etest/backend_export_gcm.go
@@ -98,7 +98,6 @@ func (l LocalExportGCMBackend) StartAndWaitReady(t testing.TB, _ e2e.Environment
 		Location:            location,
 		ProjectID:           creds.ProjectID,
 		CredentialsFromJSON: l.GCMSA,
-		PopulateDescription: true,
 	}
 	exporterOpts.DefaultUnsetFields()
 	e, err := export.New(ctx, log.NewJSONLogger(os.Stderr), nil, exporterOpts, export.NopLease())

--- a/google/internal/promqle2etest/gcm_test.go
+++ b/google/internal/promqle2etest/gcm_test.go
@@ -33,6 +33,10 @@ import (
 	"time"
 
 	gcm "cloud.google.com/go/monitoring/apiv3/v2"
+	"github.com/efficientgo/core/runutil"
+	"github.com/go-kit/log"
+	"github.com/google/go-cmp/cmp"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	dto "github.com/prometheus/client_model/go"
@@ -304,7 +308,7 @@ func TestExportGCM_PrometheusGauge(t *testing.T) {
 
 	//nolint:promlinter // Test metric.
 	gauge := promauto.With(pt.Registerer()).NewGaugeVec(prometheus.GaugeOpts{
-		Name:        "promqle2e_test_gauge_total",
+		Name:        "promqle2e_test_gauge",
 		Help:        "Test gauge used by promqle2e test framework for acceptance tests.",
 		ConstLabels: map[string]string{"repo": "github.com/GoogleCloudPlatform/prometheus"},
 	}, []string{"foo"})
@@ -348,7 +352,7 @@ func TestExportGCM_PrometheusGauge(t *testing.T) {
 func TestExportGCM_MetricHelpIngestion(t *testing.T) {
 	const (
 		interval = 15 * time.Second
-		mName    = "promqle2e_test_gauge_help_total"
+		mName    = "promqle2e_test_gauge_help"
 	)
 
 	_, _, localExportGCM := setupBackends(t)
@@ -404,23 +408,43 @@ func TestExportGCM_MetricHelpIngestion(t *testing.T) {
 	t.Cleanup(cancel)
 	pt.Run(ctx)
 
-	// Verify the help.
-	ctx = t.Context()
-	creds, err := google.CredentialsFromJSON(ctx, localExportGCM.GCMSA, gcm.DefaultAuthScopes()...)
-	if err != nil {
-		t.Fatalf("create credentials from JSON: %s", err)
-	}
-	api, err := createPromClientAgainstGCM(ctx, creds)
-	if err != nil {
-		t.Fatal(err)
-	}
-	mds, err := api.Metadata(ctx, mName, "1")
-	if err != nil {
-		t.Fatalf("getting metadata failed: %v", err)
-	}
-	m, ok := mds[mName]
-	if !ok {
-		t.Fatalf("expected %v metric not found", mName)
-	}
-	fmt.Println(m)
+	// NOTE: Because pt.Run schedules t.Run cases in parallel, this code won't wait for pt.Run to finish
+	// and has to use t.Run and t.Parallel as well.
+	// TODO(bwplotka): Add more flexibility in the promqle2etest framework to control this,
+	// current state is confusing and can pass for wrong reasons (e.g. this metric written by other test).
+	// Good enough for now.
+	t.Run("validate help", func(t *testing.T) {
+		t.Parallel()
+
+		creds, err := google.CredentialsFromJSON(ctx, localExportGCM.GCMSA, gcm.DefaultAuthScopes()...)
+		if err != nil {
+			t.Fatalf("create credentials from JSON: %s", err)
+		}
+		api, err := createPromClientAgainstGCM(ctx, creds)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := runutil.RetryWithLog(log.NewJSONLogger(os.Stderr), 10*time.Second, ctx.Done(), func() error {
+			mds, err := api.Metadata(ctx, mName, "20")
+			if err != nil {
+				return fmt.Errorf("getting metadata failed: %w", err)
+			}
+			m, ok := mds[mName]
+			if !ok {
+				return fmt.Errorf("expected %v metric not found in the returned metadata", mName)
+			}
+			diff := cmp.Diff([]v1.Metadata{
+				{Type: v1.MetricTypeGauge, Help: "Test gauge used by promqle2e test framework for acceptance tests.-changed(1)"},
+			}, m)
+			if diff != "" {
+				// Abort, no point repeating.
+				t.Errorf("resulted Matrix is different than expected: %v\n", diff)
+				return nil
+			}
+			return nil
+		}); err != nil {
+			t.Error(err)
+		}
+	})
 }

--- a/google/internal/promqle2etest/gcm_test.go
+++ b/google/internal/promqle2etest/gcm_test.go
@@ -27,15 +27,18 @@ package promqle2etest
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
 
+	gcm "cloud.google.com/go/monitoring/apiv3/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/compliance/promqle2e"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2/google"
 )
 
 // gcmServiceAccountOrFail gets the Google SA JSON content from GCM_SECRET
@@ -340,4 +343,84 @@ func TestExportGCM_PrometheusGauge(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
 	t.Cleanup(cancel)
 	pt.Run(ctx)
+}
+
+func TestExportGCM_MetricHelpIngestion(t *testing.T) {
+	const (
+		interval = 15 * time.Second
+		mName    = "promqle2e_test_gauge_help_total"
+	)
+
+	_, _, localExportGCM := setupBackends(t)
+
+	pt := promqle2e.NewScrapeStyleTest(t)
+	pt.SetCurrentTime(time.Now().Add(-10 * time.Minute)) // We only do a few scrapes, so -10m buffer is enough.
+
+	//nolint:promlinter // Test metric.
+	gauge := promauto.With(pt.Registerer()).NewGaugeVec(prometheus.GaugeOpts{
+		Name:        mName,
+		Help:        "Test gauge used by promqle2e test framework for acceptance tests.",
+		ConstLabels: map[string]string{"repo": "github.com/GoogleCloudPlatform/prometheus"},
+	}, []string{"foo"})
+	var g prometheus.Gauge
+
+	// No metric expected, gaugeVec empty.
+	pt.RecordScrape(interval)
+
+	g = gauge.WithLabelValues("bar")
+	g.Set(200)
+	pt.RecordScrape(interval).
+		Expect(g, 200, localExportGCM)
+
+	g.Sub(10)
+	pt.RecordScrape(interval).
+		Expect(g, 190, localExportGCM)
+
+	g.Add(40)
+	pt.RecordScrape(interval).
+		Expect(g, 230, localExportGCM)
+
+	// Reset to 0 (simulating instrumentation resetting metric or restarting target).
+	gauge.Reset()
+	g = gauge.WithLabelValues("bar")
+	pt.RecordScrape(interval).
+		Expect(g, 0, localExportGCM)
+
+	// Transform the recorded data to change metric HELP/description on every scrape
+	// to test the worst case scenario.
+	pt.Transform(func(recordings [][]*dto.MetricFamily) [][]*dto.MetricFamily {
+		for i := range recordings {
+			for j := range recordings[i] {
+				if recordings[i][j].Help == nil {
+					t.Fatalf("we expect Prometheus SDK to pass metric help correctly, but it's nil for %v", recordings[i][j].GetName())
+				}
+				*recordings[i][j].Help = fmt.Sprintf("%s-changed(%d)", *recordings[i][j].Help, i)
+			}
+		}
+		return recordings
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+	t.Cleanup(cancel)
+	pt.Run(ctx)
+
+	// Verify the help.
+	ctx = t.Context()
+	creds, err := google.CredentialsFromJSON(ctx, localExportGCM.GCMSA, gcm.DefaultAuthScopes()...)
+	if err != nil {
+		t.Fatalf("create credentials from JSON: %s", err)
+	}
+	api, err := createPromClientAgainstGCM(ctx, creds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mds, err := api.Metadata(ctx, mName, "1")
+	if err != nil {
+		t.Fatalf("getting metadata failed: %v", err)
+	}
+	m, ok := mds[mName]
+	if !ok {
+		t.Fatalf("expected %v metric not found", mName)
+	}
+	fmt.Println(m)
 }


### PR DESCRIPTION
cc @lyanco @realschwa 

It looks as it works 🎉 

<img width="1559" height="763" alt="image" src="https://github.com/user-attachments/assets/ab15ad89-513e-4289-b6cb-700c74bad655" />

~I don't see our [Metadata API to give it back though](https://prometheus.io/docs/prometheus/latest/querying/api/#querying-metric-metadata)... but that's ok for now? I can switch to using List time series to test this.~ EDIT: ignore me, it works, my test was wrong.

Q: Do we need feature flag for this? I literally push it hard with frequent changes and it picks the first one only as expected, looks like we can rely on this well. I think I will revert the flag addition in this PR, I propose we switch without flag for this WDYT? 🤔 @pintohutch @bernot-dev ? 
