### PR TITLE
chore: build images in the same image as our internal CI for repro

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -33,11 +33,14 @@ jobs:
     name: Ensure Google image builds (amd64)
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    container:
+      # Use the same image Louhi will use.
+      image: gcr.io/cloud-builders/docker
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+#    - name: Set up Docker Buildx
+#      uses: docker/setup-buildx-action@v3
     - name: Add vendoring
       run: |
         # Our dockerfile expects npm vendoring, yet this is done during the mirror stage.
@@ -47,7 +50,6 @@ jobs:
     - name: Ensure forked image is buildable
       run: |
         # The same commands we use for building internally.
-        ls -l web/ui/node_modules/@lezer
         docker run --rm --privileged multiarch/qemu-user-static --reset --credential yes --persistent yes
         docker buildx create --name multi-arch-builder --use
         DOCKER_BUILDKIT=1 docker buildx build -t gmp-prometheus:amd64 . -f ./Dockerfile.google --platform linux/amd64 --target=app --load

--- a/google_vendor.sh
+++ b/google_vendor.sh
@@ -7,3 +7,16 @@ set -o xtrace
 
 echo "Installing dependencies (Go & npm) with docker..."
 DOCKER_BUILDKIT=1 docker buildx build . -f ./Dockerfile.google --target vendor -o . -t gmp/sync
+
+echo "Early validation for vendored files..."
+dirs_to_check=(
+  "./vendor"
+  "./web/ui/node_modules"
+  "./web/ui/module/codemirror-promql/node_modules"
+)
+for dir in "${dirs_to_check[@]}"; do
+  if [ ! -d "$dir" ]; then
+    echo "FAIL: $dir directory is missing after vendoring...."
+    exit 1
+  fi
+done


### PR DESCRIPTION
This gets us even closer to how we run things internally for better repros. Seems fine.

I added extra validation of file that might help us debug the issue we are trying to debug on internal CI systems too.