### PR TITLE
feat(2.53.5): opt-in fix for export.match from config; ensure ApplyConfig before export

### DIFF
--- a/google/config/config.go
+++ b/google/config/config.go
@@ -2,6 +2,9 @@ package config
 
 // GoogleCloudConfig represents a custom Prometheus config entry
 // required by the hot-reloading requirements in high security k8s setups.
+//
+// All configuration parameters overrides the corresponding EXTRA_ARGS environment
+// or CLI flags.
 type GoogleCloudConfig struct {
 	Export GoogleCloudExportConfig `yaml:"export,omitempty"`
 	Query  GoogleCloudQueryConfig  `yaml:"query,omitempty"`
@@ -11,10 +14,24 @@ type GoogleCloudConfig struct {
 type GoogleCloudExportConfig struct {
 	// Compression controls the ExporterOpts.Compression setting.
 	Compression string `yaml:"compression,omitempty"`
-	// CredentialsFile controls ExporterOpts.CredentialsFile
+	// CredentialsFile controls the ExporterOpts.CredentialsFile setting.
 	CredentialsFile string `yaml:"credentials,omitempty"`
 
-	// Deprecated: This option no longer works, see https://github.com/GoogleCloudPlatform/prometheus-engine/pull/1688
+	// EnableMatch allows additional control over matching filtering
+	// given the go/gmp:matchstuck context.
+	//
+	// Available settings:
+	// * not set: This config's Match settings are ignored. Custom export.match flags are used.
+	// * false: Filtering feature is explicitly disabled; export matches all series.
+	// * true: This config's Match settings are used. Overwrites all custom export.match flags.
+	EnableMatch *bool `yaml:"enable_match,omitempty"`
+	// Match, if EnableMatch is true, controls the ExporterOpts.Matchers setting.
+	// It offers runtime change-able control of the "matchOneOf" filtering.
+	// This filtering will skip certain series from entering the series cache (for export).
+	// This data will still be ingested into Prometheus local storage.
+	//
+	// IMPORTANT: This option is prone to misconfiguration, thus opt-in and removed from the public docs.
+	// See https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed#filter-metrics.
 	Match []string `yaml:"match,omitempty"`
 }
 

--- a/google/export/export.go
+++ b/google/export/export.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -149,6 +150,13 @@ type Exporter struct {
 	// Used to construct a new metric client when options change, or at initialization. It
 	// is exposed as a variable so that unit tests may change the constructor.
 	newMetricClient func(ctx context.Context, opts ExporterOpts) (metricServiceClient, error)
+
+	// Currently applied matchers in seriesCache.matchers. Avoids locking for reads.
+	matchers Matchers
+
+	// We allow runtime config path. For startup consistency make exporter noop until export
+	// will see the first ApplyConfig.
+	configured bool
 }
 
 const (
@@ -206,7 +214,8 @@ type ExporterOpts struct {
 	// A list of metric matchers. Only Prometheus time series satisfying at
 	// least one of the matchers are exported.
 	// This option matches the semantics of the Prometheus federation match[]
-	// parameter.
+	// parameter. This is a setting from flags only, see ApplyConfig on
+	// how it's applied dynamically in conjunction with Export.Match runtime option.
 	Matchers Matchers
 
 	// Prefix under which metrics are written to GCM.
@@ -367,6 +376,7 @@ func defaultNewMetricClient(ctx context.Context, opts ExporterOpts) (metricServi
 }
 
 // New returns a new Cloud Monitoring Exporter.
+// IMPORTANT: Created exporter is noop until ApplyConfig is called at least once. This is for configuration startup consistency.
 func New(ctx context.Context, logger log.Logger, reg prometheus.Registerer, opts ExporterOpts, lease Lease) (*Exporter, error) {
 	grpc_prometheus.EnableClientHandlingTimeHistogram(
 		grpc_prometheus.WithHistogramBuckets([]float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 20, 30, 40, 50, 60}),
@@ -409,7 +419,7 @@ func New(ctx context.Context, logger log.Logger, reg prometheus.Registerer, opts
 		ctx:                  ctx,
 		opts:                 opts,
 		metricClient:         metricClient,
-		seriesCache:          newSeriesCache(logger, reg, opts.MetricTypePrefix, opts.Matchers),
+		seriesCache:          newSeriesCache(logger, reg, opts.MetricTypePrefix),
 		externalLabels:       createLabelSet(&config.Config{}, &opts),
 		newMetricClient:      defaultNewMetricClient,
 		nextc:                make(chan struct{}, 1),
@@ -418,6 +428,10 @@ func New(ctx context.Context, logger log.Logger, reg prometheus.Registerer, opts
 		lease:                lease,
 	}
 
+	// Set initial matchers.
+	e.matchers = opts.Matchers
+	e.seriesCache.setMatchers(e.matchers)
+
 	// Whenever the lease is lost, clear the series cache so we don't start off of out-of-range
 	// reset timestamps when we gain the lease again.
 	lease.OnLeaderChange(e.seriesCache.clear)
@@ -425,7 +439,6 @@ func New(ctx context.Context, logger log.Logger, reg prometheus.Registerer, opts
 	for i := range e.shards {
 		e.shards[i] = newShard(opts.Efficiency.ShardBufferSize)
 	}
-
 	return e, nil
 }
 
@@ -442,10 +455,12 @@ const (
 // ApplyConfig updates the exporter state to the given configuration. For the
 // Prometheus fork config's google_cloud entry, ExporterOpts might be
 // changed and applied to the exporter, potentially recreating the metric client.
+// NOTE: Runtime configuration will not override disable/disableAuth options from flags.
 func (e *Exporter) ApplyConfig(cfg *config.Config) (err error) {
 	// Note: We don't expect the NopExporter to call this. Only the config reloader calls it.
 	e.mtx.Lock()
 	defer e.mtx.Unlock()
+	e.configured = true
 
 	// Don't recreate the metric client each time. If the metric client is recreated, it has to
 	// potentially redo the TCP handshake. With HTTP/2, TCP connections are kept alive for a small
@@ -463,7 +478,6 @@ func (e *Exporter) ApplyConfig(cfg *config.Config) (err error) {
 		e.opts.CredentialsFile = cfg.GoogleCloud.Export.CredentialsFile
 		recreateClient = true
 	}
-	// NOTE(bwplotka): Matchers are deprecated, see https://github.com/GoogleCloudPlatform/prometheus-engine/pull/1688
 
 	lset := createLabelSet(cfg, &e.opts)
 	labelsChanged := !labels.Equal(e.externalLabels, lset)
@@ -477,20 +491,41 @@ func (e *Exporter) ApplyConfig(cfg *config.Config) (err error) {
 		}
 	}
 
-	// If changed, or we're calling this for the first time, we need to recreate the client.
+	var toApply Matchers
+	switch {
+	case cfg.GoogleCloud.Export.EnableMatch == nil:
+		// Ignore Export.Match, whatever was in flag or default wins.
+		toApply = e.opts.Matchers
+	case !*cfg.GoogleCloud.Export.EnableMatch:
+		// Explicit apply all matching (disabling the filtering).
+		toApply = nil
+	case *cfg.GoogleCloud.Export.EnableMatch:
+		// Runtime Export.Match opted-in; override:
+		for _, match := range cfg.GoogleCloud.Export.Match {
+			if err := toApply.Set(match); err != nil {
+				return err
+			}
+		}
+	}
+
 	if recreateClient {
+		// If changed, or we're calling this for the first time, we need to recreate the client.
 		e.metricClient, err = e.newMetricClient(e.ctx, e.opts)
 		if err != nil {
 			return fmt.Errorf("create metric client: %w", err)
 		}
 	}
 
+	// Updates series cache settings; those require extra care on cache entries.
+	if !e.matchers.Equals(toApply) {
+		e.matchers = toApply
+		e.seriesCache.setMatchers(e.matchers)
+	}
 	if labelsChanged {
 		e.externalLabels = lset
 		// New external labels possibly invalidate the cached series conversions.
 		e.seriesCache.forceRefresh()
 	}
-
 	return nil
 }
 
@@ -557,12 +592,17 @@ func (e *Exporter) Export(metadata MetadataFunc, batch []record.RefSample, exemp
 		return
 	}
 
-	metadata = e.wrapMetadata(metadata)
-
 	e.mtx.Lock()
+	if !e.configured {
+		// ApplyConfig must be called at least once, otherwise we risk a race between flag and runtime config change on start.
+		e.mtx.Unlock()
+		return
+	}
 	externalLabels := e.externalLabels
 	start, end, ok := e.lease.Range()
 	e.mtx.Unlock()
+
+	metadata = e.wrapMetadata(metadata)
 
 	if !ok {
 		exemplarsDropped.WithLabelValues("not-in-ha-range").Add(float64(len(exemplarMap)))
@@ -1028,6 +1068,21 @@ func (m *Matchers) Set(s string) error {
 
 func (m *Matchers) IsCumulative() bool {
 	return true
+}
+
+// Equals returns true if m is the same as other matchers. Order matters.
+//
+// NOTE: In practice order semi-matter, as the match result should be similar, but
+// things are faster or slower depending on the order. For efficiency of this function
+// and deterministic efficiency of matching, we assume order matter.
+func (m *Matchers) Equals(other Matchers) bool {
+	return slices.EqualFunc(*m, other, func(msel, osel labels.Selector) bool {
+		return slices.EqualFunc(msel, osel, func(matcher, otherMatcher *labels.Matcher) bool {
+			return matcher.Type == otherMatcher.Type &&
+					matcher.Name == otherMatcher.Name &&
+					matcher.Value == otherMatcher.Value
+		})
+	})
 }
 
 func (m *Matchers) Matches(lset labels.Labels) bool {

--- a/google/export/export_test.go
+++ b/google/export/export_test.go
@@ -16,15 +16,18 @@ package export
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
+	"slices"
+	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	monitoring_pb "cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	"github.com/go-kit/log"
+	"github.com/gogo/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	gax "github.com/googleapis/gax-go/v2"
 	"github.com/prometheus/common/model"
@@ -33,6 +36,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/record"
+	"github.com/stretchr/testify/require"
 	monitoredres_pb "google.golang.org/genproto/googleapis/api/monitoredres"
 	timestamp_pb "google.golang.org/protobuf/types/known/timestamppb"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -311,6 +315,7 @@ func TestExporter_wrapMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	require.NoError(t, e.ApplyConfig(&config.Config{}))
 
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
@@ -363,6 +368,24 @@ func TestExporter_drainBacklog(t *testing.T) {
 		return labels.FromStrings("project_id", "test", "location", "test")
 	})
 
+	{
+		// Export now requires at least one ApplyConfig call, otherwise it's noop, test it.
+		for i := range 100 {
+			// Noop.
+			e.Export(nil, []record.RefSample{
+				{Ref: 1, T: int64(i), V: float64(i)},
+			}, nil)
+		}
+
+		metricServer.Lock()
+		got := len(metricServer.samples)
+		metricServer.Unlock()
+		if got != 0 {
+			t.Fatalf("got %d, want zero, because ApplyConfig was not called", got)
+		}
+	}
+	require.NoError(t, e.ApplyConfig(&config.Config{}))
+
 	// Fill a single shard with samples.
 	wantSamples := 50
 	for i := range wantSamples {
@@ -403,77 +426,33 @@ func TestApplyConfig(t *testing.T) {
 	defer cancel()
 
 	exporterOpts := ExporterOpts{
-		DisableAuth: true,
+		DisableAuth: true, // Don't error on lack of default creds for metric client on New.
+		ProjectID:   "project_abc",
+		Matchers: func() (ret Matchers) {
+			// Initial matchers, imitating flag setting (or EXTRA ARGS).
+			require.NoError(t, ret.Set(`{ref=~"(1|2)"}`))
+			return ret
+		}(),
 	}
 	exporterOpts.DefaultUnsetFields()
+
 	e, err := New(ctx, log.NewJSONLogger(log.NewSyncWriter(os.Stderr)), nil, exporterOpts, NopLease())
 	if err != nil {
-		t.Fatalf("Create exporter: %s", err)
+		t.Fatalf("create exporter: %s", err)
 	}
-	e.SetLabelsByIDFunc(func(storage.SeriesRef) labels.Labels {
-		return labels.FromStrings("location", "us-central1-c")
+
+	// Each case will export 3 samples with ref=<ref> label and one external label overridden.
+	e.SetLabelsByIDFunc(func(ref storage.SeriesRef) labels.Labels {
+		return labels.FromStrings("location", "us-central1-c", "ref", fmt.Sprint(ref))
 	})
+	exportSamplesFn := func() {
+		e.Export(nil, []record.RefSample{{Ref: 1, T: int64(0), V: float64(0)}}, nil)
+		e.Export(nil, []record.RefSample{{Ref: 2, T: int64(0), V: float64(0)}}, nil)
+		e.Export(nil, []record.RefSample{{Ref: 3, T: int64(0), V: float64(0)}}, nil)
+	}
 
 	metricServer := testMetricService{}
-	e.newMetricClient = func(_ context.Context, opts ExporterOpts) (metricServiceClient, error) {
-		t.Helper()
-		if opts.Compression != "gzip" {
-			// This tests if ApplConfig will update new ExporterOpts
-			t.Fatalf("expected gzip compression to be test")
-		}
-		return &metricServer, nil
-	}
-	// Sends a sample with no labels. The project label is automatically added by the
-	// exporter.
-	sendSample := func() {
-		e.Export(nil, []record.RefSample{{Ref: 1, T: int64(0), V: float64(0)}}, nil)
-	}
-	// Tests all samples have the correct project ID label value.
-	testSamples := func(expectedProjectID string, expectedSampleCount int) {
-		t.Helper()
-
-		var err error
-		pollErr := wait.PollUntilContextCancel(ctx, batchDelayMax, false, func(_ context.Context) (bool, error) {
-			metricServer.Lock()
-			defer metricServer.Unlock()
-			switch len(metricServer.samples) {
-			case 0:
-				err = errors.New("no samples sent")
-				return false, nil
-			case expectedSampleCount:
-				// Good.
-			default:
-				// Sometimes there's a small delay from the thread that sends the new
-				// samples, so let's wait.
-				err = fmt.Errorf("expected %d samples but got %d", expectedSampleCount, len(metricServer.samples))
-				return false, nil
-			}
-
-			for _, sample := range metricServer.samples {
-				projectID := sample.Resource.Labels[KeyProjectID]
-				if projectID != expectedProjectID {
-					err = fmt.Errorf("expected project ID %q but got %q", expectedProjectID, projectID)
-					return false, nil
-				}
-			}
-
-			return true, nil
-		})
-		if pollErr != nil {
-			if wait.Interrupted(pollErr) && err != nil {
-				pollErr = err
-			}
-			t.Fatalf("did not get samples: %s", pollErr)
-		}
-	}
-	sendAndTestSamples := func(expectedProjectID string) {
-		// Send two samples to ensure both have correct labels.
-		sendSample()
-		sendSample()
-		sendSample()
-		testSamples(expectedProjectID, 3)
-		metricServer.clear()
-	}
+	e.metricClient = &metricServer
 
 	// In our Prometheus fork, GCM is executed before the reloader in the run group.
 	go func() {
@@ -482,54 +461,301 @@ func TestApplyConfig(t *testing.T) {
 		}
 	}()
 
-	// Initial apply with compression to trigger client reload,
-	// important to actually leverage e.newMetricClient.
-	if err := e.ApplyConfig(&config.Config{
-		GlobalConfig: config.GlobalConfig{
-			ExternalLabels: labels.FromStrings(KeyProjectID, "project-test"),
-		},
-		GoogleCloud: gcmconfig.GoogleCloudConfig{
-			Export: gcmconfig.GoogleCloudExportConfig{
-				Compression: "gzip",
-			},
-		},
-	}); err != nil {
-		t.Fatalf("Initial apply: %s", err)
+	type gcmSampleLabels struct {
+		resource []string
+		metric   []string
 	}
-	sendAndTestSamples("project-test")
 
-	// Changing project labels should work.
-	if err := e.ApplyConfig(&config.Config{
-		GlobalConfig: config.GlobalConfig{
-			ExternalLabels: labels.FromStrings(KeyProjectID, "project-abc"),
-		},
-		GoogleCloud: gcmconfig.GoogleCloudConfig{
-			Export: gcmconfig.GoogleCloudExportConfig{
-				Compression: "gzip",
-			},
-		},
-	}); err != nil {
-		t.Fatalf("Initial apply: %s", err)
+	resourceWithProject := func(projectID string) []string {
+		return []string{"cluster", "", "instance", "", "job", "", "location", "us-central1-c", "namespace", "", "project_id", projectID}
 	}
-	sendAndTestSamples("project-abc")
 
-	// Force new client to fail and ApplyConfig that should NOT create new client.
-	e.newMetricClient = func(_ context.Context, opts ExporterOpts) (metricServiceClient, error) {
-		return nil, errors.New("client should be NOT recreated")
-	}
-	if err := e.ApplyConfig(&config.Config{
-		GlobalConfig: config.GlobalConfig{
-			ExternalLabels: labels.FromStrings(KeyProjectID, "project-xyz"),
-		},
-		GoogleCloud: gcmconfig.GoogleCloudConfig{
-			Export: gcmconfig.GoogleCloudExportConfig{
-				Compression: "gzip",
+	// NOTE: All test cases share the same exporter to ensure subsequent ApplyConfigs are
+	// updating options correctly.
+	for _, tcase := range []struct {
+		name string
+
+		toApply                       *config.Config
+		expectedSamplesSeries         []gcmSampleLabels // expected samples on GCM side.
+		expectClientReload            bool
+		expectedCacheEntriesRefreshed []storage.SeriesRef
+	}{
+		{
+			name:    "no change",
+			toApply: &config.Config{},
+			expectedSamplesSeries: []gcmSampleLabels{
+				// No 3 ref due to initial matchers.
+				{metric: []string{"ref", "1"}, resource: resourceWithProject("project_abc")},
+				{metric: []string{"ref", "2"}, resource: resourceWithProject("project_abc")},
 			},
 		},
-	}); err != nil {
-		t.Fatalf("Initial apply: %s", err)
+		{
+			name: "compression change should trigger client recreation",
+			toApply: &config.Config{
+				GoogleCloud: gcmconfig.GoogleCloudConfig{
+					Export: gcmconfig.GoogleCloudExportConfig{
+						Compression: "gzip",
+					},
+				},
+			},
+			expectClientReload: true,
+			expectedSamplesSeries: []gcmSampleLabels{
+				{metric: []string{"ref", "1"}, resource: resourceWithProject("project_abc")},
+				{metric: []string{"ref", "2"}, resource: resourceWithProject("project_abc")},
+			},
+		},
+		{
+			name: "ExternalLabels change should trigger cache refresh",
+			toApply: &config.Config{
+				GlobalConfig: config.GlobalConfig{
+					ExternalLabels: labels.FromStrings(KeyProjectID, "project-test"),
+				},
+				GoogleCloud: gcmconfig.GoogleCloudConfig{
+					Export: gcmconfig.GoogleCloudExportConfig{
+						Compression: "gzip",
+					},
+				},
+			},
+			expectedCacheEntriesRefreshed: []storage.SeriesRef{1, 2},
+			expectedSamplesSeries: []gcmSampleLabels{
+				{metric: []string{"ref", "1"}, resource: resourceWithProject("project-test")},
+				{metric: []string{"ref", "2"}, resource: resourceWithProject("project-test")},
+			},
+		},
+		{
+			name: "Noop filtering change (without enable flag)",
+			toApply: &config.Config{
+				GlobalConfig: config.GlobalConfig{
+					ExternalLabels: labels.FromStrings(KeyProjectID, "project-test"),
+				},
+				GoogleCloud: gcmconfig.GoogleCloudConfig{
+					Export: gcmconfig.GoogleCloudExportConfig{
+						Compression: "gzip",
+						Match:       []string{`{ref=~"(0|3)"}`, `{ref="2"}`}, // Skip 1.
+					},
+				},
+			},
+			expectedSamplesSeries: []gcmSampleLabels{
+				{metric: []string{"ref", "1"}, resource: resourceWithProject("project-test")},
+				{metric: []string{"ref", "2"}, resource: resourceWithProject("project-test")},
+			},
+		},
+		{
+			name: "Filtering change",
+			toApply: &config.Config{
+				GlobalConfig: config.GlobalConfig{
+					ExternalLabels: labels.FromStrings(KeyProjectID, "project-test"),
+				},
+				GoogleCloud: gcmconfig.GoogleCloudConfig{
+					Export: gcmconfig.GoogleCloudExportConfig{
+						Compression: "gzip",
+						EnableMatch: proto.Bool(true),
+						Match:       []string{`{ref=~"(0|3)"}`, `{ref="2"}`}, // Skip 1.
+					},
+				},
+			},
+			expectedCacheEntriesRefreshed: []storage.SeriesRef{3}, // Expect refresh for series that're now matching.
+			expectedSamplesSeries: []gcmSampleLabels{
+				{metric: []string{"ref", "2"}, resource: resourceWithProject("project-test")},
+				{metric: []string{"ref", "3"}, resource: resourceWithProject("project-test")},
+			},
+		},
+		{
+			name: "No change, same config",
+			toApply: &config.Config{
+				GlobalConfig: config.GlobalConfig{
+					ExternalLabels: labels.FromStrings(KeyProjectID, "project-test"),
+				},
+				GoogleCloud: gcmconfig.GoogleCloudConfig{
+					Export: gcmconfig.GoogleCloudExportConfig{
+						Compression: "gzip",
+						EnableMatch: proto.Bool(true),
+						Match:       []string{`{ref=~"(0|3)"}`, `{ref="2"}`}, // Skip 1.
+					},
+				},
+			},
+			expectedSamplesSeries: []gcmSampleLabels{
+				{metric: []string{"ref", "2"}, resource: resourceWithProject("project-test")},
+				{metric: []string{"ref", "3"}, resource: resourceWithProject("project-test")},
+			},
+		},
+		{
+			name: "Filtering change (noop again)",
+			toApply: &config.Config{
+				GlobalConfig: config.GlobalConfig{
+					ExternalLabels: labels.FromStrings(KeyProjectID, "project-test"),
+				},
+				GoogleCloud: gcmconfig.GoogleCloudConfig{
+					Export: gcmconfig.GoogleCloudExportConfig{
+						Compression: "gzip",
+						// EnableMatch is now nil.
+					},
+				},
+			},
+			expectedCacheEntriesRefreshed: []storage.SeriesRef{1}, // Expect refresh for series that're now matching.
+			expectedSamplesSeries: []gcmSampleLabels{
+				// Noop means we go back to initial state of filtering.
+				{metric: []string{"ref", "1"}, resource: resourceWithProject("project-test")},
+				{metric: []string{"ref", "2"}, resource: resourceWithProject("project-test")},
+			},
+		},
+		{
+			name: "Filtering reset",
+			toApply: &config.Config{
+				GlobalConfig: config.GlobalConfig{
+					ExternalLabels: labels.FromStrings(KeyProjectID, "project-test"),
+				},
+				GoogleCloud: gcmconfig.GoogleCloudConfig{
+					Export: gcmconfig.GoogleCloudExportConfig{
+						Compression: "gzip",
+						EnableMatch: proto.Bool(false), // Explicit false means match all.
+					},
+				},
+			},
+			expectedCacheEntriesRefreshed: []storage.SeriesRef{3}, // Expect refresh for series that're now matching.
+			expectedSamplesSeries: []gcmSampleLabels{
+				{metric: []string{"ref", "1"}, resource: resourceWithProject("project-test")},
+				{metric: []string{"ref", "2"}, resource: resourceWithProject("project-test")},
+				{metric: []string{"ref", "3"}, resource: resourceWithProject("project-test")},
+			},
+		},
+		{
+			name: "Filtering change (back)",
+			toApply: &config.Config{
+				GlobalConfig: config.GlobalConfig{
+					ExternalLabels: labels.FromStrings(KeyProjectID, "project-test"),
+				},
+				GoogleCloud: gcmconfig.GoogleCloudConfig{
+					Export: gcmconfig.GoogleCloudExportConfig{
+						Compression: "gzip",
+						EnableMatch: proto.Bool(true),
+						Match:       []string{`{ref=~"(0|3)"}`, `{ref="2"}`}, // Skip 1.
+					},
+				},
+			},
+			expectedSamplesSeries: []gcmSampleLabels{
+				{metric: []string{"ref", "2"}, resource: resourceWithProject("project-test")},
+				{metric: []string{"ref", "3"}, resource: resourceWithProject("project-test")},
+			},
+		},
+		{
+			name: "Filtering change (drop all)",
+			toApply: &config.Config{
+				GlobalConfig: config.GlobalConfig{
+					ExternalLabels: labels.FromStrings(KeyProjectID, "project-test"),
+				},
+				GoogleCloud: gcmconfig.GoogleCloudConfig{
+					Export: gcmconfig.GoogleCloudExportConfig{
+						Compression: "gzip",
+						EnableMatch: proto.Bool(true),
+						Match:       []string{`{ref="1", ref="2"}`}, // Impossible match; drop all!
+					},
+				},
+			},
+			expectedSamplesSeries: []gcmSampleLabels{},
+		},
+		{
+			name: "Filtering change (force empty)",
+			toApply: &config.Config{
+				GlobalConfig: config.GlobalConfig{
+					ExternalLabels: labels.FromStrings(KeyProjectID, "project-test"),
+				},
+				GoogleCloud: gcmconfig.GoogleCloudConfig{
+					Export: gcmconfig.GoogleCloudExportConfig{
+						Compression: "gzip",
+						EnableMatch: proto.Bool(true),
+					},
+				},
+			},
+			expectedCacheEntriesRefreshed: []storage.SeriesRef{1, 2, 3}, // Expect refresh for series that're now matching.
+			expectedSamplesSeries: []gcmSampleLabels{
+				{metric: []string{"ref", "1"}, resource: resourceWithProject("project-test")},
+				{metric: []string{"ref", "2"}, resource: resourceWithProject("project-test")},
+				{metric: []string{"ref", "3"}, resource: resourceWithProject("project-test")},
+			},
+		},
+	} {
+		t.Run(tcase.name, func(t *testing.T) {
+			defer metricServer.clear()
+
+			if tcase.expectClientReload {
+				e.newMetricClient = func(_ context.Context, opts ExporterOpts) (metricServiceClient, error) {
+					t.Helper()
+					require.Equal(t, tcase.toApply.GoogleCloud.Export.Compression, opts.Compression)
+					return &metricServer, nil
+				}
+			} else {
+				e.newMetricClient = func(_ context.Context, opts ExporterOpts) (metricServiceClient, error) {
+					t.Helper()
+					t.Fatal("unexpected newMetricClient call, client should not be recreated")
+					return nil, nil
+				}
+			}
+
+			require.NoError(t, e.ApplyConfig(tcase.toApply))
+			// Verify if cache was reset, if expected.
+			// Run in closure for lock defer to work on require failures.
+			func() {
+				e.seriesCache.mtx.Lock()
+				defer e.seriesCache.mtx.Unlock()
+				for i, entry := range e.seriesCache.entries {
+					if slices.Contains(tcase.expectedCacheEntriesRefreshed, i) {
+						require.Zero(t, entry.nextRefresh, entry.lset)
+						continue
+					}
+					if entry.dropped {
+						// Dropped series is N/A.
+						continue
+					}
+					require.NotZero(t, entry.nextRefresh, entry.lset)
+				}
+			}()
+
+			// Export 3 samples (ref=1, ref=2, ref=3)
+			exportSamplesFn()
+
+			// TODO: This test is not very reliable for detecting if we send more samples than tcase.expectedSamplesSeries, find way to ensure this.
+			// For now we wait a bit (0.5s)
+			time.Sleep(10 * batchDelayMax)
+
+			var err error
+			pollErr := wait.PollUntilContextCancel(ctx, batchDelayMax, false, func(_ context.Context) (bool, error) {
+				t.Helper()
+
+				metricServer.Lock()
+				defer metricServer.Unlock()
+				switch len(metricServer.samples) {
+				case len(tcase.expectedSamplesSeries):
+					// Good.
+				default:
+					// Sometimes there's a small delay from the thread that sends the new
+					// samples, so let's wait.
+					err = fmt.Errorf("expected %d samples but got %d", len(tcase.expectedSamplesSeries), len(metricServer.samples))
+					return false, nil
+				}
+
+				// samples might have been seen out of order (series-wise). Sort it for easier testing.
+				sort.Slice(metricServer.samples, func(i, j int) bool {
+					return strings.Compare(metricServer.samples[i].Metric.String(), metricServer.samples[j].Metric.String()) < 0
+				})
+				for i, sample := range metricServer.samples {
+					require.Equal(t, labels.FromStrings(tcase.expectedSamplesSeries[i].resource...).Map(), sample.Resource.Labels)
+					require.Equal(t, labels.FromStrings(tcase.expectedSamplesSeries[i].metric...).Map(), sample.Metric.Labels)
+				}
+				return true, nil
+			})
+			if pollErr != nil {
+				if wait.Interrupted(pollErr) && err != nil {
+					pollErr = err
+				}
+				t.Fatalf("did not get samples: %s", pollErr)
+			}
+		})
 	}
-	sendAndTestSamples("project-xyz")
+
+	// Extra check if series cache clear works fine after our dynamic matchers resource releases
+	e.seriesCache.clear()
+
 }
 
 func TestDisabledExporter(t *testing.T) {
@@ -566,4 +792,55 @@ func TestDisabledExporter(t *testing.T) {
 
 	// Allow samples to be sent to the void. If we don't panic, we're good.
 	time.Sleep(batchDelayMax)
+}
+
+func TestMatchers_Equals(t *testing.T) {
+	var m Matchers
+	require.NoError(t, m.Set(`{name="foo"}`))
+	require.NoError(t, m.Set(`{name=~"foo.1"}`))
+	require.NoError(t, m.Set(`{name="foo",bar="x"}`))
+
+	var same Matchers
+	require.NoError(t, same.Set(`{name="foo"}`))
+	require.NoError(t, same.Set(`{name=~"foo.1"}`))
+	require.NoError(t, same.Set(`{name="foo",    bar="x"}`))
+
+	require.True(t, m.Equals(same))
+	require.True(t, same.Equals(m))
+
+	var diff1 Matchers
+	require.False(t, m.Equals(diff1))
+	require.False(t, diff1.Equals(m))
+
+	var diff2 Matchers
+	require.NoError(t, diff2.Set(`{name="foo"}`))
+	require.False(t, m.Equals(diff2))
+	require.False(t, diff2.Equals(m))
+
+	var diff3 Matchers
+	require.NoError(t, diff3.Set(`{name="foo"}`))
+	require.NoError(t, diff3.Set(`{name=~"foo.1"}`))
+	require.False(t, m.Equals(diff3))
+	require.False(t, diff3.Equals(m))
+
+	var diff4 Matchers
+	require.NoError(t, diff4.Set(`{name="foo"}`))
+	require.NoError(t, diff4.Set(`{name="foo",bar="x"}`))
+	require.NoError(t, diff4.Set(`{name=~"foo.1"}`))
+	require.False(t, m.Equals(diff4))
+	require.False(t, diff4.Equals(m))
+
+	var diff5 Matchers
+	require.NoError(t, diff5.Set(`{name="foo1"}`))
+	require.NoError(t, diff5.Set(`{name=~"foo.1"}`))
+	require.NoError(t, diff5.Set(`{name="foo",bar="x"}`))
+	require.False(t, m.Equals(diff5))
+	require.False(t, diff5.Equals(m))
+
+	var diff6 Matchers
+	require.NoError(t, diff6.Set(`{name="foo"}`))
+	require.NoError(t, diff6.Set(`{name=~"foo.1"}`))
+	require.NoError(t, diff6.Set(`{bar="x",name="foo"}`))
+	require.False(t, m.Equals(diff6))
+	require.False(t, diff6.Equals(m))
 }

--- a/google/export/series_cache.go
+++ b/google/export/series_cache.go
@@ -47,9 +47,10 @@ type seriesCache struct {
 	now    func() time.Time
 	pool   *pool
 
-	// Guards access to the entries and intervals maps and the lastRefresh
+	// Guards access to the entries, matchers, intervals maps and the lastRefresh
 	// field of individual cache entries.
 	mtx sync.Mutex
+
 	// Map from series reference to various cached information about it.
 	entries map[storage.SeriesRef]*seriesCacheEntry
 
@@ -117,9 +118,6 @@ func (e *seriesCacheEntry) valid() bool {
 
 // shouldRefresh returns true if the cached state should be refreshed.
 func (e *seriesCacheEntry) shouldRefresh() bool {
-	// Matchers cannot be changed at runtime and are applied to the local time series labels
-	// without external labels. Thus the dropped status can never change at runtime and thus
-	// no refresh is required.
 	return !e.dropped && time.Now().Unix() > e.nextRefresh
 }
 
@@ -132,12 +130,7 @@ func (e *seriesCacheEntry) setNextRefresh() {
 	e.nextRefresh = time.Now().Add(refreshInterval).Add(jitter).Unix()
 }
 
-func newSeriesCache(
-	logger log.Logger,
-	reg prometheus.Registerer,
-	metricTypePrefix string,
-	matchers Matchers,
-) *seriesCache {
+func newSeriesCache(logger log.Logger, reg prometheus.Registerer, metricTypePrefix string) *seriesCache {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
@@ -146,7 +139,6 @@ func newSeriesCache(
 		now:              time.Now,
 		pool:             newPool(reg),
 		entries:          map[storage.SeriesRef]*seriesCacheEntry{},
-		matchers:         matchers,
 		metricTypePrefix: metricTypePrefix,
 	}
 }
@@ -165,6 +157,36 @@ func (c *seriesCache) run(ctx context.Context) {
 				//nolint:errcheck
 				level.Error(c.logger).Log("msg", "garbage collection failed", "err", err)
 			}
+		}
+	}
+}
+
+// setMatchers changes internal series cache matcher.
+func (c *seriesCache) setMatchers(matchers Matchers) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	c.matchers = matchers
+
+	// Go through all entries and update their dropped status.
+	for _, e := range c.entries {
+		dropped := !c.matchers.Matches(e.lset)
+		if !dropped && e.dropped {
+			// Series was dropped before and is now matching.
+			e.dropped = false
+			e.nextRefresh = 0 // Force refresh to re-populate it.
+			continue
+		}
+		if dropped && !e.dropped {
+			// Series was matching before and is now dropped.
+			e.dropped = true
+			// Release resources.
+			// This is best-effort -- only needed for efficiency, not correctness.
+			c.pool.release(e.protos.gauge.proto)
+			c.pool.release(e.protos.cumulative.proto)
+			e.protos = cachedProtos{}
+			e.metadata = MetricMetadata{}
+			continue
 		}
 	}
 }
@@ -240,6 +262,7 @@ func (c *seriesCache) get(s record.RefSample, externalLabels labels.Labels, meta
 		e = &seriesCacheEntry{}
 		c.entries[ref] = e
 	}
+
 	if e.shouldRefresh() {
 		if err := c.populate(ref, e, externalLabels, metadata); err != nil {
 			//nolint:errcheck
@@ -338,6 +361,7 @@ const (
 const maxLabelCount = 100
 
 // populate cached state for the given entry.
+// Callers are expected to c.mtx.Lock before using this method.
 func (c *seriesCache) populate(ref storage.SeriesRef, entry *seriesCacheEntry, externalLabels labels.Labels, getMetadata MetadataFunc) error {
 	if entry.lset.IsEmpty() {
 		entry.lset = c.getLabelsByRef(ref)

--- a/google/export/series_cache_test.go
+++ b/google/export/series_cache_test.go
@@ -154,7 +154,7 @@ func TestExtractResource(t *testing.T) {
 }
 
 func TestSeriesCache_garbageCollect(t *testing.T) {
-	cache := newSeriesCache(nil, nil, MetricTypePrefix, nil)
+	cache := newSeriesCache(nil, nil, MetricTypePrefix)
 	// Always return empty labels. This will cause cache entries to be added but not populated,
 	// which we don't need to test garbage collection.
 	cache.getLabelsByRef = func(storage.SeriesRef) labels.Labels { return labels.EmptyLabels() }
@@ -177,5 +177,64 @@ func TestSeriesCache_garbageCollect(t *testing.T) {
 	}
 	if _, ok := cache.entries[1]; !ok {
 		t.Errorf("Expected cache entry for series 1 but cache is %v", cache.entries)
+	}
+}
+
+func TestSeriesCache_setMatchers(t *testing.T) {
+	cache := newSeriesCache(nil, nil, MetricTypePrefix)
+	cache.getLabelsByRef = func(i storage.SeriesRef) labels.Labels {
+		switch i {
+		case storage.SeriesRef(1):
+			return labels.FromStrings("ref", "1")
+		case storage.SeriesRef(2):
+			return labels.FromStrings("ref", "2")
+		}
+		t.Fatal("expected either 1 or 2 ref, got", i)
+		return nil
+	}
+
+	// Fake now second timestamp.
+	now := int64(100000)
+	cache.now = func() time.Time { return time.Unix(now, 0) }
+
+	for _, tcase := range []struct {
+		matchers                           Matchers
+		expected1Dropped, expected2Dropped bool
+	}{
+		{
+			expected1Dropped: false,
+			expected2Dropped: false,
+		},
+		{
+			matchers:         Matchers{{labels.MustNewMatcher(labels.MatchEqual, "ref", "2")}},
+			expected1Dropped: true,
+			expected2Dropped: false,
+		},
+		{
+			matchers:         Matchers{{labels.MustNewMatcher(labels.MatchEqual, "ref", "1")}},
+			expected1Dropped: false,
+			expected2Dropped: true,
+		},
+		{
+			expected1Dropped: false,
+			expected2Dropped: false,
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			cache.setMatchers(tcase.matchers)
+
+			e1, _ := cache.get(record.RefSample{Ref: 1, T: (now - 100) * 1000}, labels.EmptyLabels(), nil)
+			e2, _ := cache.get(record.RefSample{Ref: 2, T: (now - 101) * 1000}, labels.EmptyLabels(), nil)
+			if len(cache.entries) != 2 {
+				t.Fatalf("Expected exactly 2 cache entries, but cache is %v", cache.entries)
+			}
+
+			if got, want := e1.dropped, tcase.expected1Dropped; got != want {
+				t.Errorf("Expected cache entry for series 1 dropped: %v, but cache is %v", tcase.expected1Dropped, e1)
+			}
+			if got, want := e2.dropped, tcase.expected2Dropped; got != want {
+				t.Errorf("Expected cache entry for series 2 dropped: %v, but cache is %v", tcase.expected2Dropped, e2)
+			}
+		})
 	}
 }

--- a/google/export/setup/setup.go
+++ b/google/export/setup/setup.go
@@ -135,9 +135,8 @@ func ExporterOptsFlags(a *kingpin.Application, opts *export.ExporterOpts) {
 		Default(opts.Cluster).
 		StringVar(&opts.Cluster)
 
-	a.Flag("export.match", `A Prometheus time series matcher. Can be repeated. Every time series must match at least one of the matchers to be exported. This flag can be used equivalently to the match[] parameter of the Prometheus federation endpoint to selectively export data. (Example: --export.match='{job="prometheus"}' --export.match='{__name__=~"job:.*"})`).
-		Default("").
-		SetValue(&opts.Matchers)
+	a.Flag("export.match", `A Prometheus time series matcher. Matches all series if empty. Can be repeated. Every time series must match at least one of the matchers to be exported. This flag can be used equivalently to the match[] parameter of the Prometheus federation endpoint to selectively export data. External labels are excluded from matching. (Example: --export.match='{job="prometheus"}' --export.match='{__name__=~"job:.*"}). This flag can be overridden by Prometheus google_cloud.export runtime configuration.`).
+		Default("").Hidden().SetValue(&opts.Matchers)
 
 	a.Flag("export.debug.metric-prefix", "Google Cloud Monitoring metric prefix to use.").
 		Default(opts.MetricTypePrefix).

--- a/google/export/transform_test.go
+++ b/google/export/transform_test.go
@@ -1544,11 +1544,12 @@ func TestSampleBuilder(t *testing.T) {
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("%d: %s", i, c.doc), func(t *testing.T) {
-			cache := newSeriesCache(nil, nil, MetricTypePrefix, c.matchers)
+			cache := newSeriesCache(nil, nil, MetricTypePrefix)
 			// Fake lookup into TSDB.
 			cache.getLabelsByRef = func(ref storage.SeriesRef) labels.Labels {
 				return c.series[ref]
 			}
+			cache.setMatchers(c.matchers)
 
 			// Process entire input sample batch.
 			var result []*monitoring_pb.TimeSeries


### PR DESCRIPTION
Implements step 1 from go/gmp:matchstuck

NOTE: This PR also expects `ApplyConfig` to be triggered for export to work. Otherwise it's noop (similar to disable export = true). IMO this is required for reliable startup behaviour for all options (especially matching). Imagine flag is setting = matchAll and config is setting match only "A". We don't want risk random metrics user don't expect (e.g. broken ones) due to startup races. 

In practice Prometheus ensures ApplyConfig is triggered before DB is ready, but adding safecheck for other callers.