### PR TITLE
feat: add stateset support

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # Use the same image Louhi will use.
-      image: gcr.io/cloud-builders/docker
+      image: gcr.io/cloud-builders/docker:latest
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/google/export/export_test.go
+++ b/google/export/export_test.go
@@ -279,6 +279,22 @@ func TestExporter_wrapMetadata(t *testing.T) {
 			},
 			wantOK: true,
 		}, {
+			desc: "stateset metadata is returned as is",
+			mf: func(string) (MetricMetadata, bool) {
+				return MetricMetadata{
+					Metric: "some_stateset_metric",
+					Type:   model.MetricTypeStateset,
+					Help:   "stateset help",
+				}, true
+			},
+			metric: "some_stateset_metric",
+			want: MetricMetadata{
+				Metric: "some_stateset_metric",
+				Type:   model.MetricTypeStateset,
+				Help:   "stateset help",
+			},
+			wantOK: true,
+		}, {
 			desc: "not found metadata defaults to untyped",
 			mf: func(string) (MetricMetadata, bool) {
 				return MetricMetadata{}, false

--- a/google/export/series_cache.go
+++ b/google/export/series_cache.go
@@ -454,6 +454,14 @@ func (c *seriesCache) populate(ref storage.SeriesRef, entry *seriesCacheEntry, e
 			metric_pb.MetricDescriptor_DOUBLE,
 		)
 
+	case model.MetricTypeStateset:
+		protos.gauge = newSeries(
+			c.getMetricType(metricName, gcmMetricSuffixGauge, gcmMetricSuffixNone),
+			metadata.Help,
+			metric_pb.MetricDescriptor_GAUGE,
+			metric_pb.MetricDescriptor_DOUBLE,
+		)
+
 	case model.MetricTypeUnknown:
 		protos.gauge = newSeries(
 			c.getMetricType(metricName, gcmMetricSuffixUnknown, gcmMetricSuffixNone),

--- a/google/export/series_cache_test.go
+++ b/google/export/series_cache_test.go
@@ -88,6 +88,65 @@ func TestSeriesCache_populate_Info(t *testing.T) {
 	}
 }
 
+func TestSeriesCache_populate_Stateset(t *testing.T) {
+	cache := newSeriesCache(nil, nil, MetricTypePrefix)
+
+	// Mock getLabelsByRef to return labels for our info metric.
+	ref := storage.SeriesRef(1)
+	metricName := "test_stateset"
+	lset := labels.FromStrings("__name__", metricName, "job", "test_job", "instance", "test_instance", "test_stateset", "state1")
+	cache.getLabelsByRef = func(r storage.SeriesRef) labels.Labels {
+		if r == ref {
+			return lset
+		}
+		return labels.EmptyLabels()
+	}
+
+	// Prepare entry.
+	entry := &seriesCacheEntry{}
+
+	mdFunc := func(m string) (MetricMetadata, bool) {
+		if m == metricName {
+			return MetricMetadata{
+				Metric: metricName,
+				Type:   model.MetricTypeStateset,
+				Help:   "stateset help",
+			}, true
+		}
+		return MetricMetadata{}, false
+	}
+
+	// Populate cache. Provide required external labels (project_id, location).
+	externalLabels := labels.FromStrings("project_id", "my-project", "location", "us-central1")
+	err := cache.populate(ref, entry, externalLabels, mdFunc)
+	if err != nil {
+		t.Fatalf("populate failed: %v", err)
+	}
+
+	if entry.protos.gauge.proto == nil {
+		t.Fatal("expected gauge proto to be populated for Stateset metric")
+	}
+	if entry.protos.cumulative.proto != nil {
+		t.Error("expected cumulative proto to be nil for Stateset metric")
+	}
+
+	p := entry.protos.gauge.proto
+
+	if p.MetricKind != metric_pb.MetricDescriptor_GAUGE {
+		t.Errorf("expected MetricKind GAUGE, got %v", p.MetricKind)
+	}
+	if p.ValueType != metric_pb.MetricDescriptor_DOUBLE {
+		t.Errorf("expected ValueType DOUBLE, got %v", p.ValueType)
+	}
+	expectedType := "prometheus.googleapis.com/test_stateset/gauge"
+	if p.Metric.Type != expectedType {
+		t.Errorf("expected Metric Type %q, got %q", expectedType, p.Metric.Type)
+	}
+	if p.Description != "stateset help" {
+		t.Errorf("expected Description 'stateset help', got %q", p.Description)
+	}
+}
+
 func TestExtractResource(t *testing.T) {
 	cases := []struct {
 		doc            string

--- a/google/export/transform_test.go
+++ b/google/export/transform_test.go
@@ -185,6 +185,47 @@ func TestSampleBuilder(t *testing.T) {
 				},
 			},
 		}, {
+			doc: "convert stateset metric",
+			metadata: testMetadataFunc(metricMetadataMap{
+				"metric1_stateset": {Type: model.MetricTypeStateset, Help: "metric1_stateset help text"},
+			}),
+			series: seriesMap{
+				123: labels.FromStrings("job", "job1", "instance", "instance1", "__name__", "metric1_stateset", "metric1_stateset", "state1"),
+			},
+			samples: [][]record.RefSample{
+				{{Ref: 123, T: 3000, V: 1}},
+			},
+			wantSeries: []*monitoring_pb.TimeSeries{
+				{
+					Resource: &monitoredres_pb.MonitoredResource{
+						Type: "prometheus_target",
+						Labels: map[string]string{
+							"project_id": "example-project",
+							"location":   "europe",
+							"cluster":    "foo-cluster",
+							"namespace":  "",
+							"job":        "job1",
+							"instance":   "instance1",
+						},
+					},
+					Metric: &metric_pb.Metric{
+						Type:   "prometheus.googleapis.com/metric1_stateset/gauge",
+						Labels: map[string]string{"metric1_stateset": "state1"},
+					},
+					Description: "metric1_stateset help text",
+					MetricKind:  metric_pb.MetricDescriptor_GAUGE,
+					ValueType:   metric_pb.MetricDescriptor_DOUBLE,
+					Points: []*monitoring_pb.Point{{
+						Interval: &monitoring_pb.TimeInterval{
+							EndTime: &timestamp_pb.Timestamp{Seconds: 3},
+						},
+						Value: &monitoring_pb.TypedValue{
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 1},
+						},
+					}},
+				},
+			},
+		}, {
 			doc: "convert untyped",
 			metadata: testMetadataFunc(metricMetadataMap{
 				"metric1": {Type: model.MetricTypeUnknown, Help: "metric1 help text"},


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/prometheus-engine/issues/490

Let's fix statesets which tend to be also used in OM 1 https://prometheus.io/docs/specs/om/open_metrics_spec/#stateset-1 and are present in KSM (see https://github.com/GoogleCloudPlatform/prometheus-engine/issues/490#issuecomment-1940851286)

Shamelessly copying @bernot-dev testability patterns from https://github.com/GoogleCloudPlatform/prometheus/pull/267

The only unsupported thing will be now `gaugehistogram` which I never seen in practice -- I don't think those are well supported in Prometheus OSS as well, nor if Monarch even supports those 🤔 