### PR TITLE
google patch[deps]: fix release-2.45.3-gmp vulnerabilities

### DIFF
--- a/Dockerfile.google
+++ b/Dockerfile.google
@@ -1,5 +1,5 @@
 ARG IMAGE_BUILD_NODEJS=us-central1-docker.pkg.dev/serverless-runtimes/google-22/runtimes/nodejs22:latest@sha256:9e88442205b4c956ca4996c2be626db6ef412043182cdd620e741d0d5e14b6a6
-ARG IMAGE_BUILD_GO=google-go.pkg.dev/golang:1.26.3@sha256:3e25fdade56f35be3bca41f8a141a66ca834f1c01fdf55414d4a1e1c987a985c
+ARG IMAGE_BUILD_GO=google-go.pkg.dev/golang:1.26.4@sha256:3444149d0a7e3f7cfb9c2db65f0f75676fe6ad04de3ce72674efb120c08dd1c1
 
 ARG IMAGE_BASE_DEBUG=gcr.io/distroless/base-nossl-debian12:debug
 ARG IMAGE_BASE=gke.gcr.io/gke-distroless/libc:gke_distroless_20260601.00_p0@sha256:1b74f92a381c5269d5018b08ce0464cfcb310b6b9b6d98767ba3300838483fc4


### PR DESCRIPTION
Updating Go and image vulnerabilities using
```
./gmpctl.sh vulnfix
```
