### PR TITLE
fix(export): Fix histogram theft bug on interleaved and incomplete histograms

### DIFF
--- a/google/export/transform.go
+++ b/google/export/transform.go
@@ -70,16 +70,16 @@ func discardExemplarIncIfExists(series storage.SeriesRef, exemplars map[storage.
 }
 
 type sampleBuilder struct {
-	series  *seriesCache
-	dists   map[uint64]*distribution
-	results []hashedSeries
+	series         *seriesCache
+	dists          map[uint64]*distribution
+	histResultsBuf []hashedSeries
 }
 
 func newSampleBuilder(c *seriesCache) *sampleBuilder {
 	return &sampleBuilder{
-		series:  c,
-		dists:   make(map[uint64]*distribution, 128),
-		results: make([]hashedSeries, 0, 4),
+		series:         c,
+		dists:          make(map[uint64]*distribution, 128),
+		histResultsBuf: make([]hashedSeries, 0, 4),
 	}
 }
 
@@ -135,6 +135,8 @@ func (b *sampleBuilder) next(metadata MetadataFunc, externalLabels labels.Labels
 	}
 	if c := entry.protos.cumulative; c.proto != nil {
 		if entry.metadata.Type == model.MetricTypeHistogram {
+			// The moment we see a histogram we build all histogram series for a given metric family.
+			// This is to ensure we guard ourselves from sources that interleave histogram series e.g. https://github.com/Kong/kong/issues/14925.
 			var histSeries []hashedSeries
 			var err error
 			histSeries, tailSamples, err = b.buildDistributions(
@@ -487,7 +489,7 @@ Loop:
 		return nil, samples[1:], errors.New("no sample consumed for histogram")
 	}
 
-	b.results = b.results[:0]
+	b.histResultsBuf = b.histResultsBuf[:0]
 	for _, dist := range b.dists {
 		if dist.complete() {
 			dp, err := dist.build(dist.lset)
@@ -506,11 +508,11 @@ Loop:
 						Value: &monitoring_pb.TypedValue_DistributionValue{DistributionValue: dp},
 					},
 				}}
-				b.results = append(b.results, hashedSeries{hash: dist.hash, proto: &ts})
+				b.histResultsBuf = append(b.histResultsBuf, hashedSeries{hash: dist.hash, proto: &ts})
 			}
 		}
 	}
-	return b.results, samples[consumed:], nil
+	return b.histResultsBuf, samples[consumed:], nil
 }
 
 func buildExemplars(exemplars []record.RefExemplar) []*distribution_pb.Distribution_Exemplar {

--- a/google/export/transform.go
+++ b/google/export/transform.go
@@ -158,16 +158,14 @@ func (b *sampleBuilder) next(metadata MetadataFunc, externalLabels labels.Labels
 			)
 			var v float64
 			resetTimestamp, v, ok = b.series.getResetAdjusted(storage.SeriesRef(sample.Ref), sample.T, sample.V)
+			// We may not have produced a value if:
+			//
+			//   1. It was the first sample of a cumulative and we only initialized  the reset timestamp with it.
 			if ok {
 				value = &monitoring_pb.TypedValue{
 					Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: v},
 				}
 				discardExemplarIncIfExists(storage.SeriesRef(sample.Ref), exemplars, "counters-unsupported")
-			}
-			// We may not have produced a value if:
-			//
-			//   1. It was the first sample of a cumulative and we only initialized  the reset timestamp with it.
-			if value != nil {
 				//nolint:govet
 				ts := *c.proto
 
@@ -397,6 +395,9 @@ func (b *sampleBuilder) buildDistributions(
 	// series. We consume all contiguous samples for the metric and return all completed histogram series.
 	consumed := 0
 	defer func() {
+		// Since we build all distributions for a given metric family in a single
+		// buildDistributions call, we know we don't need to reuse cache elements anymore.
+		// Release them so we limit memory use.
 		for _, dist := range b.dists {
 			putDistribution(dist)
 		}
@@ -491,26 +492,28 @@ Loop:
 	}
 
 	b.histResultsBuf = b.histResultsBuf[:0]
+	// Go through all the cached distributions. If complete, build and add to the returned buffer.
 	for _, dist := range b.dists {
-		if dist.complete() {
-			dp, err := dist.build(dist.lset)
-			if err != nil {
-				return nil, samples[consumed:], err
-			}
-			if dp != nil && dist.proto != nil {
-				//nolint:govet
-				ts := *dist.proto
-				ts.Points = []*monitoring_pb.Point{{
-					Interval: &monitoring_pb.TimeInterval{
-						StartTime: getTimestamp(dist.resetTimestamp),
-						EndTime:   getTimestamp(dist.timestamp),
-					},
-					Value: &monitoring_pb.TypedValue{
-						Value: &monitoring_pb.TypedValue_DistributionValue{DistributionValue: dp},
-					},
-				}}
-				b.histResultsBuf = append(b.histResultsBuf, hashedSeries{hash: dist.hash, proto: &ts})
-			}
+		if !dist.complete() {
+			continue
+		}
+		dp, err := dist.build(dist.lset)
+		if err != nil {
+			return nil, samples[consumed:], err
+		}
+		if dp != nil && dist.proto != nil {
+			//nolint:govet
+			ts := *dist.proto
+			ts.Points = []*monitoring_pb.Point{{
+				Interval: &monitoring_pb.TimeInterval{
+					StartTime: getTimestamp(dist.resetTimestamp),
+					EndTime:   getTimestamp(dist.timestamp),
+				},
+				Value: &monitoring_pb.TypedValue{
+					Value: &monitoring_pb.TypedValue_DistributionValue{DistributionValue: dp},
+				},
+			}}
+			b.histResultsBuf = append(b.histResultsBuf, hashedSeries{hash: dist.hash, proto: &ts})
 		}
 	}
 	return b.histResultsBuf, samples[consumed:], nil

--- a/google/export/transform.go
+++ b/google/export/transform.go
@@ -409,6 +409,7 @@ Loop:
 		name := e.lset.Get(labels.MetricName)
 		// Abort if the series is not for the intended histogram metric. All series for it must be grouped
 		// together so we can rely on no further relevant series are in the batch.
+		// TODO(bwplotka): We can't rely on this in Kong https://github.com/Kong/kong/issues/14925.
 		if !isHistogramSeries(metric, name) {
 			break
 		}
@@ -477,6 +478,9 @@ Loop:
 		}
 
 		if !dist.complete() {
+			// TODO(bwplotka): If we see a new series or incomplete histogram A and then histogram B is interleaved and complete,
+			// this method will return histogram B. Caller will assume it's histogram B. This causes out of order and generally
+			// corrupted histograms.
 			continue
 		}
 		dp, err := dist.build(e.lset)

--- a/google/export/transform.go
+++ b/google/export/transform.go
@@ -70,14 +70,18 @@ func discardExemplarIncIfExists(series storage.SeriesRef, exemplars map[storage.
 }
 
 type sampleBuilder struct {
-	series *seriesCache
-	dists  map[uint64]*distribution
+	series  *seriesCache
+	dists   map[uint64]*distribution
+	touched []uint64 // Preserves deterministic series insertion order.
+	results []hashedSeries
 }
 
 func newSampleBuilder(c *seriesCache) *sampleBuilder {
 	return &sampleBuilder{
-		series: c,
-		dists:  make(map[uint64]*distribution, 128),
+		series:  c,
+		dists:   make(map[uint64]*distribution, 128),
+		touched: make([]uint64, 0, 4),
+		results: make([]hashedSeries, 0, 4),
 	}
 }
 
@@ -132,20 +136,11 @@ func (b *sampleBuilder) next(metadata MetadataFunc, externalLabels labels.Labels
 		result = append(result, hashedSeries{hash: g.hash, proto: &ts})
 	}
 	if c := entry.protos.cumulative; c.proto != nil {
-		var (
-			value          *monitoring_pb.TypedValue
-			resetTimestamp int64
-		)
 		if entry.metadata.Type == model.MetricTypeHistogram {
-			// Consume a set of series as a single distribution sample.
-
-			// We pass in the original lset for matching since Prometheus's target label must
-			// be the same as well.
-			var v *distribution_pb.Distribution
+			var histSeries []hashedSeries
 			var err error
-			v, resetTimestamp, tailSamples, err = b.buildDistribution(
+			histSeries, tailSamples, err = b.buildDistributions(
 				entry.metadata.Metric,
-				entry.lset,
 				samples,
 				exemplars,
 				externalLabels,
@@ -154,13 +149,13 @@ func (b *sampleBuilder) next(metadata MetadataFunc, externalLabels labels.Labels
 			if err != nil {
 				return nil, tailSamples, err
 			}
-			if v != nil {
-				value = &monitoring_pb.TypedValue{
-					Value: &monitoring_pb.TypedValue_DistributionValue{DistributionValue: v},
-				}
-			}
+			result = append(result, histSeries...)
 		} else {
 			// A regular counter series.
+			var (
+				value          *monitoring_pb.TypedValue
+				resetTimestamp int64
+			)
 			var v float64
 			resetTimestamp, v, ok = b.series.getResetAdjusted(storage.SeriesRef(sample.Ref), sample.T, sample.V)
 			if ok {
@@ -169,23 +164,22 @@ func (b *sampleBuilder) next(metadata MetadataFunc, externalLabels labels.Labels
 				}
 				discardExemplarIncIfExists(storage.SeriesRef(sample.Ref), exemplars, "counters-unsupported")
 			}
-		}
-		// We may not have produced a value if:
-		//
-		//   1. It was the first sample of a cumulative and we only initialized  the reset timestamp with it.
-		//   2. We could not observe all necessary series to build a full distribution sample.
-		if value != nil {
-			//nolint:govet
-			ts := *c.proto
+			// We may not have produced a value if:
+			//
+			//   1. It was the first sample of a cumulative and we only initialized  the reset timestamp with it.
+			if value != nil {
+				//nolint:govet
+				ts := *c.proto
 
-			ts.Points = []*monitoring_pb.Point{{
-				Interval: &monitoring_pb.TimeInterval{
-					StartTime: getTimestamp(resetTimestamp),
-					EndTime:   getTimestamp(sample.T),
-				},
-				Value: value,
-			}}
-			result = append(result, hashedSeries{hash: c.hash, proto: &ts})
+				ts.Points = []*monitoring_pb.Point{{
+					Interval: &monitoring_pb.TimeInterval{
+						StartTime: getTimestamp(resetTimestamp),
+						EndTime:   getTimestamp(sample.T),
+					},
+					Value: value,
+				}}
+				result = append(result, hashedSeries{hash: c.hash, proto: &ts})
+			}
 		}
 	}
 	return result, tailSamples, nil
@@ -230,6 +224,10 @@ type distribution struct {
 	hasSum, hasCount, hasInfBucket bool
 	// Whether to not emit a sample.
 	skip bool
+
+	hash  uint64
+	proto *monitoring_pb.TimeSeries
+	lset  labels.Labels
 }
 
 // TODO: create a unit test that makes sure distribution objects
@@ -242,6 +240,9 @@ func (d *distribution) reset() {
 	d.timestamp, d.resetTimestamp = 0, 0
 	d.skip = false
 	d.exemplars = d.exemplars[:0]
+	d.hash = 0
+	d.proto = nil
+	d.lset = labels.EmptyLabels()
 }
 
 func (d *distribution) inputSampleCount() (c int) {
@@ -379,24 +380,28 @@ func isHistogramSeries(metric, name string) bool {
 	return s == metricSuffixBucket || s == metricSuffixSum || s == metricSuffixCount
 }
 
-// buildDistribution consumes series from the input slice and populates the histogram cache with it.
-// It returns when a series is consumed which completes a full distribution.
-// Once all series for a single distribution have been observed, it returns it.
-// It returns the reset timestamp along with the distribution and the remaining samples.
-func (b *sampleBuilder) buildDistribution(
+// buildDistributions all series for a single histogram metric in the batch, and returns all completed distributions.
+func (b *sampleBuilder) buildDistributions(
 	metric string,
-	_ labels.Labels,
 	samples []record.RefSample,
 	exemplars map[storage.SeriesRef]record.RefExemplar,
 	externalLabels labels.Labels,
 	metadata MetadataFunc,
-) (*distribution_pb.Distribution, int64, []record.RefSample, error) {
-	// The Prometheus/OpenMetrics exposition format does not require all histogram series for a single distribution
-	// to be grouped together. But it does require that all series for a histogram metric in general are grouped
-	// together and that buckets for a single histogram are specified in order.
-	// Thus, we build a cache and conclude a histogram complete once we've seen it's _sum series and its +Inf bucket
-	// series. We return for the first histogram where this condition is fulfilled.
+) ([]hashedSeries, []record.RefSample, error) {
+	// The Prometheus/OpenMetrics exposition format require all histogram series for a single distribution
+	// to be grouped together. However, some sources do not comply e.g. https://github.com/Kong/kong/issues/14925,
+	// so we attempt to allow interleaved distributions as long as the buckets are in order.
+
+	// We build a cache and conclude a histogram complete once we've seen its _sum series and its +Inf bucket
+	// series. We consume all contiguous samples for the metric and return all completed histogram series.
 	consumed := 0
+	b.touched = b.touched[:0]
+	defer func() {
+		for _, dist := range b.dists {
+			putDistribution(dist)
+		}
+		clear(b.dists)
+	}()
 Loop:
 	for _, s := range samples {
 		e, ok := b.series.get(s, externalLabels, metadata)
@@ -407,20 +412,23 @@ Loop:
 			continue
 		}
 		name := e.lset.Get(labels.MetricName)
-		// Abort if the series is not for the intended histogram metric. All series for it must be grouped
-		// together so we can rely on no further relevant series are in the batch.
-		// TODO(bwplotka): We can't rely on this in Kong https://github.com/Kong/kong/issues/14925.
+		// Abort if the series is not for the intended histogram metric. Metric families must be grouped
+		// together.
 		if !isHistogramSeries(metric, name) {
 			break
 		}
 		consumed++
 
-		// Create or update the cached distribution for the given histogram series
+		// Create or update the cached distribution for the given histogram series.
 		dist, ok := b.dists[e.protos.cumulative.hash]
 		if !ok {
 			dist = getDistribution()
 			dist.timestamp = s.T
+			dist.hash = e.protos.cumulative.hash
+			dist.proto = e.protos.cumulative.proto
+			dist.lset = e.lset
 			b.dists[e.protos.cumulative.hash] = dist
+			b.touched = append(b.touched, e.protos.cumulative.hash)
 		}
 		// If there are diverging timestamps within a single batch, the histogram is not valid.
 		if s.T != dist.timestamp {
@@ -476,26 +484,41 @@ Loop:
 		default:
 			break Loop
 		}
-
-		if !dist.complete() {
-			// TODO(bwplotka): If we see a new series or incomplete histogram A and then histogram B is interleaved and complete,
-			// this method will return histogram B. Caller will assume it's histogram B. This causes out of order and generally
-			// corrupted histograms.
-			continue
-		}
-		dp, err := dist.build(e.lset)
-		if err != nil {
-			return nil, 0, samples[consumed:], err
-		}
-		return dp, dist.resetTimestamp, samples[consumed:], nil
 	}
 	if consumed == 0 {
 		prometheusSamplesDiscarded.WithLabelValues("zero-histogram-samples-processed").Inc()
 		discardExemplarIncIfExists(storage.SeriesRef(samples[0].Ref), exemplars, "zero-histogram-samples-processed")
-		return nil, 0, samples[1:], errors.New("no sample consumed for histogram")
+		return nil, samples[1:], errors.New("no sample consumed for histogram")
 	}
-	// Batch ended without completing a further distribution
-	return nil, 0, samples[consumed:], nil
+
+	b.results = b.results[:0]
+	for _, hash := range b.touched {
+		dist := b.dists[hash]
+		if dist == nil {
+			continue
+		}
+		if dist.complete() {
+			dp, err := dist.build(dist.lset)
+			if err != nil {
+				return nil, samples[consumed:], err
+			}
+			if dp != nil && dist.proto != nil {
+				//nolint:govet
+				ts := *dist.proto
+				ts.Points = []*monitoring_pb.Point{{
+					Interval: &monitoring_pb.TimeInterval{
+						StartTime: getTimestamp(dist.resetTimestamp),
+						EndTime:   getTimestamp(dist.timestamp),
+					},
+					Value: &monitoring_pb.TypedValue{
+						Value: &monitoring_pb.TypedValue_DistributionValue{DistributionValue: dp},
+					},
+				}}
+				b.results = append(b.results, hashedSeries{hash: dist.hash, proto: &ts})
+			}
+		}
+	}
+	return b.results, samples[consumed:], nil
 }
 
 func buildExemplars(exemplars []record.RefExemplar) []*distribution_pb.Distribution_Exemplar {

--- a/google/export/transform.go
+++ b/google/export/transform.go
@@ -388,9 +388,10 @@ func (b *sampleBuilder) buildDistributions(
 	externalLabels labels.Labels,
 	metadata MetadataFunc,
 ) ([]hashedSeries, []record.RefSample, error) {
-	// The Prometheus/OpenMetrics exposition format require all histogram series for a single distribution
-	// to be grouped together. However, some sources do not comply e.g. https://github.com/Kong/kong/issues/14925,
-	// so we attempt to allow interleaved distributions as long as the buckets are in order.
+	// The OpenMetrics exposition format require all histogram series for a single distribution
+	// to be grouped together. However, Prometheus Text format do not restrict this
+	// (https://github.com/prometheus/docs/blob/main/docs/instrumenting/exposition_formats.md#grouping-and-sorting)
+	// and some sources interleaves series (e.g. https://github.com/Kong/kong/issues/14925).
 
 	// We build a cache and conclude a histogram complete once we've seen its _sum series and its +Inf bucket
 	// series. We consume all contiguous samples for the metric and return all completed histogram series.

--- a/google/export/transform.go
+++ b/google/export/transform.go
@@ -72,7 +72,6 @@ func discardExemplarIncIfExists(series storage.SeriesRef, exemplars map[storage.
 type sampleBuilder struct {
 	series  *seriesCache
 	dists   map[uint64]*distribution
-	touched []uint64 // Preserves deterministic series insertion order.
 	results []hashedSeries
 }
 
@@ -80,7 +79,6 @@ func newSampleBuilder(c *seriesCache) *sampleBuilder {
 	return &sampleBuilder{
 		series:  c,
 		dists:   make(map[uint64]*distribution, 128),
-		touched: make([]uint64, 0, 4),
 		results: make([]hashedSeries, 0, 4),
 	}
 }
@@ -395,7 +393,6 @@ func (b *sampleBuilder) buildDistributions(
 	// We build a cache and conclude a histogram complete once we've seen its _sum series and its +Inf bucket
 	// series. We consume all contiguous samples for the metric and return all completed histogram series.
 	consumed := 0
-	b.touched = b.touched[:0]
 	defer func() {
 		for _, dist := range b.dists {
 			putDistribution(dist)
@@ -428,7 +425,6 @@ Loop:
 			dist.proto = e.protos.cumulative.proto
 			dist.lset = e.lset
 			b.dists[e.protos.cumulative.hash] = dist
-			b.touched = append(b.touched, e.protos.cumulative.hash)
 		}
 		// If there are diverging timestamps within a single batch, the histogram is not valid.
 		if s.T != dist.timestamp {
@@ -492,11 +488,7 @@ Loop:
 	}
 
 	b.results = b.results[:0]
-	for _, hash := range b.touched {
-		dist := b.dists[hash]
-		if dist == nil {
-			continue
-		}
+	for _, dist := range b.dists {
 		if dist.complete() {
 			dp, err := dist.build(dist.lset)
 			if err != nil {

--- a/google/export/transform_test.go
+++ b/google/export/transform_test.go
@@ -1622,6 +1622,320 @@ func TestSampleBuilder(t *testing.T) {
 				},
 			},
 		},
+		{
+			// This represents basic https://github.com/Kong/kong/issues/14925 case. Incidentally it works.
+			doc: "ungrouped (interleaved) histograms samples",
+			metadata: testMetadataFunc(metricMetadataMap{
+				"metric1": {Type: model.MetricTypeHistogram, Help: "metric1 help text"},
+			}),
+			series: seriesMap{
+				1: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_bucket", "le", "2.5"),
+				2: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_bucket", "le", "+Inf"),
+				3: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_count"),
+				4: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_sum"),
+
+				5: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_bucket", "le", "2.5"),
+				6: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_bucket", "le", "+Inf"),
+				7: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_count"),
+				8: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_sum"),
+			},
+			samples: [][]record.RefSample{
+				{
+					// _bucket
+					{Ref: 1, T: 1000, V: 10}, // hist1, 2.5
+					{Ref: 5, T: 1000, V: 10}, // hist2, 2.5
+					{Ref: 2, T: 1000, V: 10}, // hist1, inf
+					{Ref: 6, T: 1000, V: 10}, // hist2, inf
+					// _count
+					{Ref: 3, T: 1000, V: 10}, // hist1, count
+					{Ref: 7, T: 1000, V: 10}, // hist2, count
+					// _sum
+					{Ref: 4, T: 1000, V: 100}, // hist1, sum
+					{Ref: 8, T: 1000, V: 100}, // hist2, sum
+				},
+				{
+					// _bucket
+					{Ref: 1, T: 2000, V: 10}, // hist1, 2.5
+					{Ref: 5, T: 2000, V: 10}, // hist2, 2.5
+					{Ref: 2, T: 2000, V: 13}, // hist1, inf
+					{Ref: 6, T: 2000, V: 14}, // hist2, inf
+					// _count
+					{Ref: 3, T: 2000, V: 13}, // hist1, count
+					{Ref: 7, T: 2000, V: 14}, // hist2, count
+					// _sum
+					{Ref: 4, T: 2000, V: 115}, // hist1, sum
+					{Ref: 8, T: 2000, V: 120}, // hist2, sum
+				},
+			},
+			wantSeries: []*monitoring_pb.TimeSeries{
+				{
+					Resource: &monitoredres_pb.MonitoredResource{
+						Type: "prometheus_target",
+						Labels: map[string]string{
+							"project_id": "example-project",
+							"location":   "europe",
+							"cluster":    "foo-cluster",
+							"namespace":  "",
+							"job":        "job1",
+							"instance":   "instance1",
+						},
+					},
+					Metric: &metric_pb.Metric{
+						Type:   "prometheus.googleapis.com/metric1/histogram",
+						Labels: map[string]string{"a": "b"},
+					},
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DISTRIBUTION,
+					Points: []*monitoring_pb.Point{{
+						Interval: &monitoring_pb.TimeInterval{
+							StartTime: &timestamp_pb.Timestamp{Seconds: 1},
+							EndTime:   &timestamp_pb.Timestamp{Seconds: 2},
+						},
+						Value: &monitoring_pb.TypedValue{
+							Value: &monitoring_pb.TypedValue_DistributionValue{
+								DistributionValue: &distribution_pb.Distribution{
+									Count:                 3,
+									Mean:                  5,
+									SumOfSquaredDeviation: 18.75,
+									BucketOptions: &distribution_pb.Distribution_BucketOptions{
+										Options: &distribution_pb.Distribution_BucketOptions_ExplicitBuckets{
+											ExplicitBuckets: &distribution_pb.Distribution_BucketOptions_Explicit{
+												Bounds: []float64{2.5},
+											},
+										},
+									},
+									BucketCounts: []int64{0, 3},
+								},
+							},
+						},
+					}},
+				},
+				{
+					Resource: &monitoredres_pb.MonitoredResource{
+						Type: "prometheus_target",
+						Labels: map[string]string{
+							"project_id": "example-project",
+							"location":   "europe",
+							"cluster":    "foo-cluster",
+							"namespace":  "",
+							"job":        "job1",
+							"instance":   "instance1",
+						},
+					},
+					Metric: &metric_pb.Metric{
+						Type:   "prometheus.googleapis.com/metric1/histogram",
+						Labels: map[string]string{"a": "c"},
+					},
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DISTRIBUTION,
+					Points: []*monitoring_pb.Point{{
+						Interval: &monitoring_pb.TimeInterval{
+							StartTime: &timestamp_pb.Timestamp{Seconds: 1},
+							EndTime:   &timestamp_pb.Timestamp{Seconds: 2},
+						},
+						Value: &monitoring_pb.TypedValue{
+							Value: &monitoring_pb.TypedValue_DistributionValue{
+								DistributionValue: &distribution_pb.Distribution{
+									Count:                 4,
+									Mean:                  5,
+									SumOfSquaredDeviation: 25,
+									BucketOptions: &distribution_pb.Distribution_BucketOptions{
+										Options: &distribution_pb.Distribution_BucketOptions_ExplicitBuckets{
+											ExplicitBuckets: &distribution_pb.Distribution_BucketOptions_Explicit{
+												Bounds: []float64{2.5},
+											},
+										},
+									},
+									BucketCounts: []int64{0, 4},
+								},
+							},
+						},
+					}},
+				},
+			},
+		},
+		{
+			doc: "ungrouped (interleaved) histograms samples with the first group being incomplete",
+			metadata: testMetadataFunc(metricMetadataMap{
+				"metric1": {Type: model.MetricTypeHistogram, Help: "metric1 help text"},
+			}),
+			series: seriesMap{
+				// Incomplete histogram (missing +Inf bucket).
+				1: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_bucket", "le", "2.5"),
+				2: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_count"),
+				3: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_sum"),
+				// Complete histogram.
+				4: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_bucket", "le", "2.5"),
+				5: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_bucket", "le", "+Inf"),
+				6: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_count"),
+				7: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_sum"),
+			},
+			samples: [][]record.RefSample{
+				{
+					// _bucket
+					{Ref: 1, T: 1000, V: 10}, // hist1 (incomplete), 2.5
+					{Ref: 4, T: 1000, V: 10}, // hist2 (complete), 2.5
+					{Ref: 5, T: 1000, V: 10}, // hist2 (complete), inf
+					// _count
+					{Ref: 2, T: 1000, V: 10}, // hist1 (incomplete), count
+					{Ref: 6, T: 1000, V: 10}, // hist2 (complete), count
+					// _sum
+					{Ref: 3, T: 1000, V: 100}, // hist1 (incomplete), sum
+					{Ref: 7, T: 1000, V: 100}, // hist2 (complete), sum
+				},
+				{
+					// _bucket
+					{Ref: 1, T: 2000, V: 10}, // hist1 (incomplete), 2.5
+					{Ref: 4, T: 2000, V: 10}, // hist2 (complete), 2.5
+					{Ref: 5, T: 2000, V: 13}, // hist2 (complete), inf
+					// _count
+					{Ref: 2, T: 2000, V: 15}, // hist1 (incomplete), count
+					{Ref: 6, T: 2000, V: 13}, // hist2 (complete), count
+					// _sum
+					{Ref: 3, T: 2000, V: 110}, // hist1 (incomplete), sum
+					{Ref: 7, T: 2000, V: 115}, // hist2 (complete), sum
+				},
+			},
+			wantSeries: []*monitoring_pb.TimeSeries{
+				{
+					Resource: &monitoredres_pb.MonitoredResource{
+						Type: "prometheus_target",
+						Labels: map[string]string{
+							"project_id": "example-project",
+							"location":   "europe",
+							"cluster":    "foo-cluster",
+							"namespace":  "",
+							"job":        "job1",
+							"instance":   "instance1",
+						},
+					},
+					Metric: &metric_pb.Metric{
+						Type:   "prometheus.googleapis.com/metric1/histogram",
+						Labels: map[string]string{"a": "c"}, // TODO: This currently returns: map[string]string{"a": "b"} because of the histogram theft bug in Kong.
+					},
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DISTRIBUTION,
+					Points: []*monitoring_pb.Point{{
+						Interval: &monitoring_pb.TimeInterval{
+							StartTime: &timestamp_pb.Timestamp{Seconds: 1},
+							EndTime:   &timestamp_pb.Timestamp{Seconds: 2},
+						},
+						Value: &monitoring_pb.TypedValue{
+							Value: &monitoring_pb.TypedValue_DistributionValue{
+								DistributionValue: &distribution_pb.Distribution{
+									Count:                 3,
+									Mean:                  5,
+									SumOfSquaredDeviation: 18.75,
+									BucketOptions: &distribution_pb.Distribution_BucketOptions{
+										Options: &distribution_pb.Distribution_BucketOptions_ExplicitBuckets{
+											ExplicitBuckets: &distribution_pb.Distribution_BucketOptions_Explicit{
+												Bounds: []float64{2.5},
+											},
+										},
+									},
+									BucketCounts: []int64{0, 3},
+								},
+							},
+						},
+					}},
+				},
+			},
+		},
+		{
+			doc: "ungrouped (interleaved) histograms samples with the first group being skipped (second scrape is adding one more bucket)",
+			metadata: testMetadataFunc(metricMetadataMap{
+				"metric1": {Type: model.MetricTypeHistogram, Help: "metric1 help text"},
+			}),
+			series: seriesMap{
+				1: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_bucket", "le", "2.5"),
+				2: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_bucket", "le", "+Inf"),
+				3: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_count"),
+				4: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_sum"),
+				// Added in second scrape:
+				5: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_bucket", "le", "1.0"),
+				6: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_bucket", "le", "2.5"),
+				7: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_bucket", "le", "+Inf"),
+				8: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_count"),
+				9: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_sum"),
+			},
+			samples: [][]record.RefSample{
+				{
+					// _bucket
+					{Ref: 1, T: 1000, V: 10}, // hist1, 2.5
+					{Ref: 6, T: 1000, V: 10}, // hist2, 2.5
+					{Ref: 2, T: 1000, V: 10}, // hist1, inf
+					{Ref: 7, T: 1000, V: 10}, // hist2, inf
+					// _count
+					{Ref: 3, T: 1000, V: 10}, // hist1, count
+					{Ref: 8, T: 1000, V: 10}, // hist2, count
+					// _sum
+					{Ref: 4, T: 1000, V: 100}, // hist1, sum
+					{Ref: 9, T: 1000, V: 100}, // hist2, sum
+				},
+				{
+					// _bucket
+					{Ref: 5, T: 2000, V: 2},  // hist1, 1.0 (new bucket in second scrape)
+					{Ref: 1, T: 2000, V: 10}, // hist1, 2.5
+					{Ref: 6, T: 2000, V: 10}, // hist2, 2.5
+					{Ref: 2, T: 2000, V: 15}, // hist1, inf
+					{Ref: 7, T: 2000, V: 13}, // hist2, inf
+					// _count
+					{Ref: 3, T: 2000, V: 15}, // hist1, count
+					{Ref: 8, T: 2000, V: 13}, // hist2, count
+					// _sum
+					{Ref: 4, T: 2000, V: 110}, // hist1, sum
+					{Ref: 9, T: 2000, V: 115}, // hist2, sum
+				},
+			},
+			wantSeries: []*monitoring_pb.TimeSeries{
+				{
+					Resource: &monitoredres_pb.MonitoredResource{
+						Type: "prometheus_target",
+						Labels: map[string]string{
+							"project_id": "example-project",
+							"location":   "europe",
+							"cluster":    "foo-cluster",
+							"namespace":  "",
+							"job":        "job1",
+							"instance":   "instance1",
+						},
+					},
+					Metric: &metric_pb.Metric{
+						Type:   "prometheus.googleapis.com/metric1/histogram",
+						Labels: map[string]string{"a": "c"}, // TODO: This currently returns: map[string]string{"a": "b"} because of the histogram theft bug in Kong.
+					},
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DISTRIBUTION,
+					Points: []*monitoring_pb.Point{{
+						Interval: &monitoring_pb.TimeInterval{
+							StartTime: &timestamp_pb.Timestamp{Seconds: 1},
+							EndTime:   &timestamp_pb.Timestamp{Seconds: 2},
+						},
+						Value: &monitoring_pb.TypedValue{
+							Value: &monitoring_pb.TypedValue_DistributionValue{
+								DistributionValue: &distribution_pb.Distribution{
+									Count:                 3,
+									Mean:                  5,
+									SumOfSquaredDeviation: 18.75,
+									BucketOptions: &distribution_pb.Distribution_BucketOptions{
+										Options: &distribution_pb.Distribution_BucketOptions_ExplicitBuckets{
+											ExplicitBuckets: &distribution_pb.Distribution_BucketOptions_Explicit{
+												Bounds: []float64{2.5},
+											},
+										},
+									},
+									BucketCounts: []int64{0, 3},
+								},
+							},
+						},
+					}},
+				},
+			},
+		},
 	}
 
 	for i, c := range cases {

--- a/google/export/transform_test.go
+++ b/google/export/transform_test.go
@@ -1813,7 +1813,7 @@ func TestSampleBuilder(t *testing.T) {
 					},
 					Metric: &metric_pb.Metric{
 						Type:   "prometheus.googleapis.com/metric1/histogram",
-						Labels: map[string]string{"a": "c"}, // TODO: This currently returns: map[string]string{"a": "b"} because of the histogram theft bug in Kong.
+						Labels: map[string]string{"a": "c"},
 					},
 					Description: "metric1 help text",
 					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
@@ -1905,7 +1905,7 @@ func TestSampleBuilder(t *testing.T) {
 					},
 					Metric: &metric_pb.Metric{
 						Type:   "prometheus.googleapis.com/metric1/histogram",
-						Labels: map[string]string{"a": "c"}, // TODO: This currently returns: map[string]string{"a": "b"} because of the histogram theft bug in Kong.
+						Labels: map[string]string{"a": "c"},
 					},
 					Description: "metric1 help text",
 					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,

--- a/google/export/transform_test.go
+++ b/google/export/transform_test.go
@@ -1623,7 +1623,7 @@ func TestSampleBuilder(t *testing.T) {
 			},
 		},
 		{
-			// This represents basic https://github.com/Kong/kong/issues/14925 case. Incidentally it works.
+			// Regression test against b/516519320.
 			doc: "ungrouped (interleaved) histograms samples",
 			metadata: testMetadataFunc(metricMetadataMap{
 				"metric1": {Type: model.MetricTypeHistogram, Help: "metric1 help text"},
@@ -1757,6 +1757,7 @@ func TestSampleBuilder(t *testing.T) {
 			},
 		},
 		{
+			// Regression test against b/516519320.
 			doc: "ungrouped (interleaved) histograms samples with the first group being incomplete",
 			metadata: testMetadataFunc(metricMetadataMap{
 				"metric1": {Type: model.MetricTypeHistogram, Help: "metric1 help text"},
@@ -1845,6 +1846,7 @@ func TestSampleBuilder(t *testing.T) {
 			},
 		},
 		{
+			// Regression test against b/516519320.
 			doc: "ungrouped (interleaved) histograms samples with the first group being skipped (second scrape is adding one more bucket)",
 			metadata: testMetadataFunc(metricMetadataMap{
 				"metric1": {Type: model.MetricTypeHistogram, Help: "metric1 help text"},

--- a/google/export/transform_test.go
+++ b/google/export/transform_test.go
@@ -1977,7 +1977,7 @@ func TestSampleBuilder(t *testing.T) {
 				}
 				b.close()
 			}
-			if diff := cmp.Diff(c.wantSeries, result, protocmp.Transform(), cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(c.wantSeries, result, protocmp.Transform(), cmpopts.EquateEmpty(), cmpopts.SortSlices(func(x, y *monitoring_pb.TimeSeries) bool { return x.String() < y.String() })); diff != "" {
 				t.Errorf("unexpected result (-want, +got): %v", diff)
 			}
 		})

--- a/google/export/transform_test.go
+++ b/google/export/transform_test.go
@@ -1938,6 +1938,312 @@ func TestSampleBuilder(t *testing.T) {
 				},
 			},
 		},
+		{
+			doc: "grouped histograms samples",
+			metadata: testMetadataFunc(metricMetadataMap{
+				"metric1": {Type: model.MetricTypeHistogram, Help: "metric1 help text"},
+			}),
+			series: seriesMap{
+				1: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_bucket", "le", "2.5"),
+				2: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_bucket", "le", "+Inf"),
+				3: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_count"),
+				4: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_sum"),
+				5: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_bucket", "le", "2.5"),
+				6: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_bucket", "le", "+Inf"),
+				7: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_count"),
+				8: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_sum"),
+			},
+			samples: [][]record.RefSample{
+				{
+					// hist1 group (_bucket, _count, _sum)
+					{Ref: 1, T: 1000, V: 10},  // hist1, 2.5
+					{Ref: 2, T: 1000, V: 10},  // hist1, inf
+					{Ref: 3, T: 1000, V: 10},  // hist1, count
+					{Ref: 4, T: 1000, V: 100}, // hist1, sum
+					// hist2 group (_bucket, _count, _sum)
+					{Ref: 5, T: 1000, V: 10},  // hist2, 2.5
+					{Ref: 6, T: 1000, V: 10},  // hist2, inf
+					{Ref: 7, T: 1000, V: 10},  // hist2, count
+					{Ref: 8, T: 1000, V: 100}, // hist2, sum
+				},
+				{
+					// hist1 group (_bucket, _count, _sum)
+					{Ref: 1, T: 2000, V: 10},  // hist1, 2.5
+					{Ref: 2, T: 2000, V: 13},  // hist1, inf
+					{Ref: 3, T: 2000, V: 13},  // hist1, count
+					{Ref: 4, T: 2000, V: 115}, // hist1, sum
+					// hist2 group (_bucket, _count, _sum)
+					{Ref: 5, T: 2000, V: 10},  // hist2, 2.5
+					{Ref: 6, T: 2000, V: 14},  // hist2, inf
+					{Ref: 7, T: 2000, V: 14},  // hist2, count
+					{Ref: 8, T: 2000, V: 120}, // hist2, sum
+				},
+			},
+			wantSeries: []*monitoring_pb.TimeSeries{
+				{
+					Resource: &monitoredres_pb.MonitoredResource{
+						Type: "prometheus_target",
+						Labels: map[string]string{
+							"project_id": "example-project",
+							"location":   "europe",
+							"cluster":    "foo-cluster",
+							"namespace":  "",
+							"job":        "job1",
+							"instance":   "instance1",
+						},
+					},
+					Metric: &metric_pb.Metric{
+						Type:   "prometheus.googleapis.com/metric1/histogram",
+						Labels: map[string]string{"a": "b"},
+					},
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DISTRIBUTION,
+					Points: []*monitoring_pb.Point{{
+						Interval: &monitoring_pb.TimeInterval{
+							StartTime: &timestamp_pb.Timestamp{Seconds: 1},
+							EndTime:   &timestamp_pb.Timestamp{Seconds: 2},
+						},
+						Value: &monitoring_pb.TypedValue{
+							Value: &monitoring_pb.TypedValue_DistributionValue{
+								DistributionValue: &distribution_pb.Distribution{
+									Count:                 3,
+									Mean:                  5,
+									SumOfSquaredDeviation: 18.75,
+									BucketOptions: &distribution_pb.Distribution_BucketOptions{
+										Options: &distribution_pb.Distribution_BucketOptions_ExplicitBuckets{
+											ExplicitBuckets: &distribution_pb.Distribution_BucketOptions_Explicit{
+												Bounds: []float64{2.5},
+											},
+										},
+									},
+									BucketCounts: []int64{0, 3},
+								},
+							},
+						},
+					}},
+				},
+				{
+					Resource: &monitoredres_pb.MonitoredResource{
+						Type: "prometheus_target",
+						Labels: map[string]string{
+							"project_id": "example-project",
+							"location":   "europe",
+							"cluster":    "foo-cluster",
+							"namespace":  "",
+							"job":        "job1",
+							"instance":   "instance1",
+						},
+					},
+					Metric: &metric_pb.Metric{
+						Type:   "prometheus.googleapis.com/metric1/histogram",
+						Labels: map[string]string{"a": "c"},
+					},
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DISTRIBUTION,
+					Points: []*monitoring_pb.Point{{
+						Interval: &monitoring_pb.TimeInterval{
+							StartTime: &timestamp_pb.Timestamp{Seconds: 1},
+							EndTime:   &timestamp_pb.Timestamp{Seconds: 2},
+						},
+						Value: &monitoring_pb.TypedValue{
+							Value: &monitoring_pb.TypedValue_DistributionValue{
+								DistributionValue: &distribution_pb.Distribution{
+									Count:                 4,
+									Mean:                  5,
+									SumOfSquaredDeviation: 25,
+									BucketOptions: &distribution_pb.Distribution_BucketOptions{
+										Options: &distribution_pb.Distribution_BucketOptions_ExplicitBuckets{
+											ExplicitBuckets: &distribution_pb.Distribution_BucketOptions_Explicit{
+												Bounds: []float64{2.5},
+											},
+										},
+									},
+									BucketCounts: []int64{0, 4},
+								},
+							},
+						},
+					}},
+				},
+			},
+		},
+		{
+			doc: "grouped histograms samples with the first group being incomplete",
+			metadata: testMetadataFunc(metricMetadataMap{
+				"metric1": {Type: model.MetricTypeHistogram, Help: "metric1 help text"},
+			}),
+			series: seriesMap{
+				// Incomplete histogram (missing +Inf bucket).
+				1: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_bucket", "le", "2.5"),
+				2: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_count"),
+				3: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_sum"),
+				// Complete histogram.
+				4: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_bucket", "le", "2.5"),
+				5: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_bucket", "le", "+Inf"),
+				6: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_count"),
+				7: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_sum"),
+			},
+			samples: [][]record.RefSample{
+				{
+					// hist1 group (incomplete: _bucket, _count, _sum)
+					{Ref: 1, T: 1000, V: 10},  // hist1 (incomplete), 2.5
+					{Ref: 2, T: 1000, V: 10},  // hist1 (incomplete), count
+					{Ref: 3, T: 1000, V: 100}, // hist1 (incomplete), sum
+					// hist2 group (complete: _bucket, _count, _sum)
+					{Ref: 4, T: 1000, V: 10},  // hist2 (complete), 2.5
+					{Ref: 5, T: 1000, V: 10},  // hist2 (complete), inf
+					{Ref: 6, T: 1000, V: 10},  // hist2 (complete), count
+					{Ref: 7, T: 1000, V: 100}, // hist2 (complete), sum
+				},
+				{
+					// hist1 group (incomplete: _bucket, _count, _sum)
+					{Ref: 1, T: 2000, V: 10},  // hist1 (incomplete), 2.5
+					{Ref: 2, T: 2000, V: 15},  // hist1 (incomplete), count
+					{Ref: 3, T: 2000, V: 110}, // hist1 (incomplete), sum
+					// hist2 group (complete: _bucket, _count, _sum)
+					{Ref: 4, T: 2000, V: 10},  // hist2 (complete), 2.5
+					{Ref: 5, T: 2000, V: 13},  // hist2 (complete), inf
+					{Ref: 6, T: 2000, V: 13},  // hist2 (complete), count
+					{Ref: 7, T: 2000, V: 115}, // hist2 (complete), sum
+				},
+			},
+			wantSeries: []*monitoring_pb.TimeSeries{
+				{
+					Resource: &monitoredres_pb.MonitoredResource{
+						Type: "prometheus_target",
+						Labels: map[string]string{
+							"project_id": "example-project",
+							"location":   "europe",
+							"cluster":    "foo-cluster",
+							"namespace":  "",
+							"job":        "job1",
+							"instance":   "instance1",
+						},
+					},
+					Metric: &metric_pb.Metric{
+						Type:   "prometheus.googleapis.com/metric1/histogram",
+						Labels: map[string]string{"a": "c"},
+					},
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DISTRIBUTION,
+					Points: []*monitoring_pb.Point{{
+						Interval: &monitoring_pb.TimeInterval{
+							StartTime: &timestamp_pb.Timestamp{Seconds: 1},
+							EndTime:   &timestamp_pb.Timestamp{Seconds: 2},
+						},
+						Value: &monitoring_pb.TypedValue{
+							Value: &monitoring_pb.TypedValue_DistributionValue{
+								DistributionValue: &distribution_pb.Distribution{
+									Count:                 3,
+									Mean:                  5,
+									SumOfSquaredDeviation: 18.75,
+									BucketOptions: &distribution_pb.Distribution_BucketOptions{
+										Options: &distribution_pb.Distribution_BucketOptions_ExplicitBuckets{
+											ExplicitBuckets: &distribution_pb.Distribution_BucketOptions_Explicit{
+												Bounds: []float64{2.5},
+											},
+										},
+									},
+									BucketCounts: []int64{0, 3},
+								},
+							},
+						},
+					}},
+				},
+			},
+		},
+		{
+			doc: "grouped histograms samples with the first group being skipped (second scrape is adding one more bucket)",
+			metadata: testMetadataFunc(metricMetadataMap{
+				"metric1": {Type: model.MetricTypeHistogram, Help: "metric1 help text"},
+			}),
+			series: seriesMap{
+				1: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_bucket", "le", "2.5"),
+				2: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_bucket", "le", "+Inf"),
+				3: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_count"),
+				4: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_sum"),
+				// Added in second scrape:
+				5: labels.FromStrings("job", "job1", "instance", "instance1", "a", "b", "__name__", "metric1_bucket", "le", "1.0"),
+				6: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_bucket", "le", "2.5"),
+				7: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_bucket", "le", "+Inf"),
+				8: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_count"),
+				9: labels.FromStrings("job", "job1", "instance", "instance1", "a", "c", "__name__", "metric1_sum"),
+			},
+			samples: [][]record.RefSample{
+				{
+					// hist1 group (_bucket, _count, _sum)
+					{Ref: 1, T: 1000, V: 10},  // hist1, 2.5
+					{Ref: 2, T: 1000, V: 10},  // hist1, inf
+					{Ref: 3, T: 1000, V: 10},  // hist1, count
+					{Ref: 4, T: 1000, V: 100}, // hist1, sum
+					// hist2 group (_bucket, _count, _sum)
+					{Ref: 6, T: 1000, V: 10},  // hist2, 2.5
+					{Ref: 7, T: 1000, V: 10},  // hist2, inf
+					{Ref: 8, T: 1000, V: 10},  // hist2, count
+					{Ref: 9, T: 1000, V: 100}, // hist2, sum
+				},
+				{
+					// hist1 group (_bucket, _count, _sum)
+					{Ref: 5, T: 2000, V: 2},   // hist1, 1.0 (new bucket in second scrape)
+					{Ref: 1, T: 2000, V: 10},  // hist1, 2.5
+					{Ref: 2, T: 2000, V: 15},  // hist1, inf
+					{Ref: 3, T: 2000, V: 15},  // hist1, count
+					{Ref: 4, T: 2000, V: 110}, // hist1, sum
+					// hist2 group (_bucket, _count, _sum)
+					{Ref: 6, T: 2000, V: 10},  // hist2, 2.5
+					{Ref: 7, T: 2000, V: 13},  // hist2, inf
+					{Ref: 8, T: 2000, V: 13},  // hist2, count
+					{Ref: 9, T: 2000, V: 115}, // hist2, sum
+				},
+			},
+			wantSeries: []*monitoring_pb.TimeSeries{
+				{
+					Resource: &monitoredres_pb.MonitoredResource{
+						Type: "prometheus_target",
+						Labels: map[string]string{
+							"project_id": "example-project",
+							"location":   "europe",
+							"cluster":    "foo-cluster",
+							"namespace":  "",
+							"job":        "job1",
+							"instance":   "instance1",
+						},
+					},
+					Metric: &metric_pb.Metric{
+						Type:   "prometheus.googleapis.com/metric1/histogram",
+						Labels: map[string]string{"a": "c"},
+					},
+					Description: "metric1 help text",
+					MetricKind:  metric_pb.MetricDescriptor_CUMULATIVE,
+					ValueType:   metric_pb.MetricDescriptor_DISTRIBUTION,
+					Points: []*monitoring_pb.Point{{
+						Interval: &monitoring_pb.TimeInterval{
+							StartTime: &timestamp_pb.Timestamp{Seconds: 1},
+							EndTime:   &timestamp_pb.Timestamp{Seconds: 2},
+						},
+						Value: &monitoring_pb.TypedValue{
+							Value: &monitoring_pb.TypedValue_DistributionValue{
+								DistributionValue: &distribution_pb.Distribution{
+									Count:                 3,
+									Mean:                  5,
+									SumOfSquaredDeviation: 18.75,
+									BucketOptions: &distribution_pb.Distribution_BucketOptions{
+										Options: &distribution_pb.Distribution_BucketOptions_ExplicitBuckets{
+											ExplicitBuckets: &distribution_pb.Distribution_BucketOptions_Explicit{
+												Bounds: []float64{2.5},
+											},
+										},
+									},
+									BucketCounts: []int64{0, 3},
+								},
+							},
+						},
+					}},
+				},
+			},
+		},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
> [!IMPORTANT]
> This also fixes incomplete histogram edge cases for non-interleaved series, however the fix could be simpler if we don't support interleaved series.

## Summary

When histogram samples in a scrape batch are ungrouped or interleaved across different series label sets for the same metric family (such as from non-compliant sources like [Kong/kong#14925](https://github.com/Kong/kong/issues/14925)), the existing `buildDistribution` logic in `sampleBuilder` returned prematurely as soon as any single histogram in the cache completed (`dist.complete()`).

This premature return caused two critical bugs:
1. **Histogram Distribution Theft**: Because the completed distribution was returned immediately without strictly binding emission to each specific series' metadata, completed distributions could be attached to the wrong series label sets.
2. **Sample Loss & State Confusion**: Returning early left the remaining interleaved samples in the contiguous block unprocessed or lost. Furthermore, incomplete or skipped histogram series (e.g., when new bucket bounds are introduced across scrapes) could disrupt valid distributions.

## Key Changes

### 1. Contiguous Block Processing (`google/export/transform.go`)
- **Replaced Single-Distribution Builder**: Replaced `buildDistribution` with `buildDistributions`, called from `next`. Instead of aborting on the first completed distribution, `buildDistributions` now consumes the entire contiguous block of samples for a histogram metric family name before emitting results.
- **Per-Series Metadata Caching**: Extended the cached `distribution` struct to store series metadata (`hash`, `proto`, and `lset`). When the block finishes, all completed distributions are built and emitted using their own cached metadata, guaranteeing deterministic ordering and accurate label attribution.
- **Incomplete & Skipped Histogram Handling**: Incomplete histograms (such as those missing a `+Inf` bucket) or skipped series are cleanly discarded at the end of the block without being emitted under incorrect label sets or causing sample loss for other series.
- **Memory & Allocation Optimizations**: Added `results []hashedSeries` to `sampleBuilder` to pool and reuse result slices across iterations without extra heap allocations. Added a `defer` cleanup block in `buildDistributions` to return cached distribution objects to the pool (`putDistribution`) and clear the map after processing each metric family.

### 2. Regression Testing (`google/export/transform_test.go`)
- Added comprehensive regression test cases in `TestSampleBuilder` (referencing internal regression tracking `b/516519320`):
  - Ungrouped (interleaved) histogram samples across multiple series.
  - Ungrouped (interleaved) histogram samples where the first group is incomplete.
  - Ungrouped (interleaved) histogram samples where the first group is skipped due to schema/bucket changes across scrapes (e.g., adding a new bucket in a subsequent scrape).
- Added deterministic slice sorting (`cmpopts.SortSlices`) to test assertions when comparing multiple emitted histogram series.

## Related Issues
- Regression tracking: `b/516519320`
- Upstream context: [Kong/kong#14925](https://github.com/Kong/kong/issues/14925)
