### PR TITLE
Increase GCM test timeout to 20 minutes

### DIFF
--- a/google/internal/promqle2etest/Makefile
+++ b/google/internal/promqle2etest/Makefile
@@ -2,7 +2,7 @@ GCM_SECRET?=
 .PHONY: test
 test:  ## Run export unit tests that will use GCM if GCM_SECRET is present.
 ifneq ($(GCM_SECRET),)
-	go test -tags gcme2e -timeout 15m -v ./...
+	go test -tags gcme2e -timeout 20m -v ./...
 else
 	@echo "Secret not provided, skipping!"
 endif


### PR DESCRIPTION
Increased timeout for GCM tests from 15m to 20m.