### PR TITLE
tracing: remove explicit schema URL when building tracer provider resource (release-2.45.3-gmp)

### DIFF
--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -143,7 +143,6 @@ func buildTracerProvider(ctx context.Context, tracingCfg config.TracingConfig) (
 	// Create a resource describing the service and the runtime.
 	res, err := resource.New(
 		ctx,
-		resource.WithSchemaURL(semconv.SchemaURL),
 		resource.WithAttributes(
 			semconv.ServiceNameKey.String(serviceName),
 			semconv.ServiceVersionKey.String(version.Version),


### PR DESCRIPTION
Remove explicit schema URL when building tracer provider resource in `tracing/tracing.go` to avoid schema URL mismatch errors when resources are merged.

Rationale -- we don't need to have extra upgrade step: https://github.com/GoogleCloudPlatform/prometheus-engine/pull/2015#discussion_r3650551618