### PR TITLE
google patch[deps]: fix release-3.13.0-gmp vulnerabilities

### DIFF
--- a/Dockerfile.google
+++ b/Dockerfile.google
@@ -5,9 +5,9 @@
 # For the lack of the other official Google nodejs image, we use serverless project
 # images to build the Prometheus frontent (https://cloud.google.com/docs/buildpacks/base-images).
 ARG IMAGE_BUILD_NODEJS=gke.gcr.io/debian-base:bookworm-v1.0.8-gke.9@sha256:fc22d178e95261ca59987ca396107c4bd8b6f90d4a64c7f387f22eeb4529546a
-ARG IMAGE_BUILD_GO=google-go.pkg.dev/golang:1.26.5@sha256:5075e8b0e1a7913c2274737c1a8b379ea264322c082bd21d3911d196dce46559
+ARG IMAGE_BUILD_GO=google-go.pkg.dev/golang:1.26.7@sha256:2f110d472e26e5c6b1c93f40a3ea6f88fe8954902cd4518d7ce99d836a158ceb
 ARG IMAGE_BASE_DEBUG=gcr.io/distroless/base-nossl-debian12:debug@sha256:2b89aea887933b8595f62c3d7e05a2718a0594e21e506952ce55b68b537f4fb6
-ARG IMAGE_BASE=gke.gcr.io/gke-distroless/libc:gke_distroless_20260801.00_p0@sha256:0625a71ac0c78014343a6743ff368f50d1001769d4e181390dff83515deaf1f5
+ARG IMAGE_BASE=gke.gcr.io/gke-distroless/libc:gke_distroless_20260815.00_p0@sha256:532c7001d381c6f0c6fe684bb3235596cd532340c463df855a0ea168a83d783e
 
 FROM --platform=$BUILDPLATFORM ${IMAGE_BUILD_GO} AS gobase
 WORKDIR /workspace


### PR DESCRIPTION
Updating Go and image vulnerabilities using
```
./gmpctl.sh vulnfix
```
